### PR TITLE
Add register-login and profile saplings from Grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 
 /sapling-dev-server/circuits
 /sapling-dev-server/register-login.js
+/sapling-dev-server/profile
 
 # misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /canopy**/lib
 
 /sapling-dev-server/circuits
+/sapling-dev-server/register-login.js
 
 # misc
 .DS_Store

--- a/sapling-dev-server/Dockerfile
+++ b/sapling-dev-server/Dockerfile
@@ -21,6 +21,14 @@ RUN npm config set unsafe-perm true
 
 COPY . .
 
+# Hack to add register-login sapling until there's a distribution strategy for
+# saplings
+RUN git clone https://github.com/hyperledger/grid
+RUN cp -r grid/grid-ui/saplings/register-login /saplings
+RUN cd /saplings/register-login && \
+  npm install && \
+  npm run deploy
+
 RUN cd /saplings/circuits && \
   npm install && \
   npm run deploy

--- a/sapling-dev-server/Dockerfile
+++ b/sapling-dev-server/Dockerfile
@@ -21,11 +21,17 @@ RUN npm config set unsafe-perm true
 
 COPY . .
 
-# Hack to add register-login sapling until there's a distribution strategy for
-# saplings
+# Hack to add register-login and profiles saplings until there's a distribution
+# strategy for saplings
 RUN git clone https://github.com/hyperledger/grid
 RUN cp -r grid/grid-ui/saplings/register-login /saplings
+RUN cp -r grid/grid-ui/saplings/profile /saplings
+
 RUN cd /saplings/register-login && \
+  npm install && \
+  npm run deploy
+
+RUN cd /saplings/profile && \
   npm install && \
   npm run deploy
 

--- a/sapling-dev-server/configSaplings
+++ b/sapling-dev-server/configSaplings
@@ -6,5 +6,13 @@
     ],
     "styleFiles": [],
     "workerFiles": []
-  }
+  },
+  {
+   "namespace": "login",
+   "runtimeFiles": [
+     "localhost:3030/sapling-dev-server/register-login.js"
+   ],
+   "styleFiles": [],
+   "workerFiles": []
+ }
 ]

--- a/sapling-dev-server/configSaplings
+++ b/sapling-dev-server/configSaplings
@@ -2,9 +2,11 @@
   {
     "namespace": "profile",
     "runtimeFiles": [
-      "localhost:3030/sapling-dev-server/profile.js"
+      "localhost:3030/sapling-dev-server/profile/js/profile.js"
     ],
-    "styleFiles": [],
+    "styleFiles": [
+      "localhost:3030/sapling-dev-server/profile/css/profile.css"
+    ],
     "workerFiles": []
   },
   {


### PR DESCRIPTION
This PR adds the register-login and profiles saplings that are being developed as part of the Grid  UI work. 

### To test:
1. Run:
```
docker-compose -f docker/docker-compose.yaml up --build
```

2. Go to `http://localhost:3030/`. You will be asked to login as an existing user or register a new user:
<img width="1256" alt="Screen Shot 2020-04-09 at 9 20 45 AM" src="https://user-images.githubusercontent.com/14094978/78905339-76a2ce00-7a43-11ea-8af2-14d9935bcfe0.png">

3. Once you've register a new user, click the profile icon in the bottom left corner on the menu, which you forward you to `http://localhost:3030/profile`:
<img width="1207" alt="Screen Shot 2020-04-09 at 9 27 38 AM" src="https://user-images.githubusercontent.com/14094978/78905989-62130580-7a44-11ea-8fc8-0a16e197fa82.png">


P.S The profile sapling is still under active development so bugs or issues might be present. 

