### PR TITLE
Add header with sapling name and button to propose circuits

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -99,7 +99,7 @@ services:
         REACT_APP_SAPLING_URL: '/sapling-dev-server'
         SPLINTER_URL: 'http://splinterd-alpha:8085'
         SAPLING_URL: ' http://sapling-dev-server-alpha:80'
-    image: splinter-ui
+    image: splinter-ui-alpha
     container_name: splinter-ui-alpha
     expose:
       - 80
@@ -183,7 +183,7 @@ services:
         REACT_APP_SAPLING_URL: '/sapling-dev-server'
         SPLINTER_URL: 'http://splinterd-beta:8085'
         SAPLING_URL: ' http://sapling-dev-server-beta:80'
-    image: splinter-ui
+    image: splinter-ui-beta
     container_name: splinter-ui-beta
     expose:
       - 80

--- a/saplings/circuits/src/components/MainHeader.js
+++ b/saplings/circuits/src/components/MainHeader.js
@@ -15,20 +15,16 @@
  */
 
 import React from 'react';
-import './App.css';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
-import { library } from '@fortawesome/fontawesome-svg-core';
+import './MainHeader.scss';
 
-import MainHeader from './components/MainHeader';
-
-library.add(faPlus);
-
-function App() {
+const MainHeader = () => {
   return (
-    <div className="circuits-app">
-      <MainHeader />
+    <div className="main-header">
+      <div>
+        <h4 className="circuits-title">Circuits</h4>
+      </div>
     </div>
   );
-}
+};
 
-export default App;
+export default MainHeader;

--- a/saplings/circuits/src/components/MainHeader.scss
+++ b/saplings/circuits/src/components/MainHeader.scss
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import './App.css';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
-import { library } from '@fortawesome/fontawesome-svg-core';
+.main-header {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 3rem;
 
-import MainHeader from './components/MainHeader';
-
-library.add(faPlus);
-
-function App() {
-  return (
-    <div className="circuits-app">
-      <MainHeader />
-    </div>
-  );
+  .circuits-title {
+    color: var(--color-grey);
+    font-weight: 100;
+    margin: 0 1rem 0 0;
+  }
 }
-
-export default App;

--- a/saplings/circuits/src/components/ProposeCircuitButton.js
+++ b/saplings/circuits/src/components/ProposeCircuitButton.js
@@ -15,18 +15,22 @@
  */
 
 import React from 'react';
-import ProposeCircuitButton from './ProposeCircuitButton';
-import './MainHeader.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import './ProposeCircuitButton.scss';
 
-const MainHeader = () => {
+const ProposeCircuitButton = () => {
+  const plusSign = (
+    <span className="add-sign">
+      <FontAwesomeIcon icon="plus" />
+    </span>
+  );
+
   return (
-    <div className="main-header">
-      <div>
-        <h4 className="circuits-title">Circuits</h4>
-      </div>
-      <ProposeCircuitButton />
-    </div>
+    <button type="button" className="propose-circuit-btn">
+      {plusSign}
+      <span className="btn-text">Propose New Circuit</span>
+    </button>
   );
 };
 
-export default MainHeader;
+export default ProposeCircuitButton;

--- a/saplings/circuits/src/components/ProposeCircuitButton.scss
+++ b/saplings/circuits/src/components/ProposeCircuitButton.scss
@@ -14,19 +14,37 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import ProposeCircuitButton from './ProposeCircuitButton';
-import './MainHeader.scss';
+.propose-circuit-btn {
+  align-items: center;
+  background: var(--color-primary);
+  border: none;
+  border-radius: 4px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  color: var(--color-text-on-dark);
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  height: 3rem;
+  width: 15rem;
 
-const MainHeader = () => {
-  return (
-    <div className="main-header">
-      <div>
-        <h4 className="circuits-title">Circuits</h4>
-      </div>
-      <ProposeCircuitButton />
-    </div>
-  );
-};
+  .add-sign {
+    font-size: 2rem;
+  }
+}
 
-export default MainHeader;
+@media only screen and (max-width: 600px) {
+  .propose-circuit-btn {
+    height: 2rem;
+    width: auto;
+
+    // hide button text in small screens
+    .btn-text {
+      display: none;
+    }
+
+    .add-sign {
+      font-size: 1rem;
+    }
+  }
+}


### PR DESCRIPTION
### To test

1. Run 
```
docker-compose -f docker/docker-compose.yaml  build sapling-dev-server-alpha sapling-dev-server-beta 
```
2. Run 
```
docker-compose -f docker/docker-compose.yaml up
```

3. Go to `localhost:3030/circuits`:
<img width="1273" alt="Screen Shot 2020-04-09 at 10 14 47 AM" src="https://user-images.githubusercontent.com/14094978/78910744-fed8a180-7a4a-11ea-8ddd-1a36aed6422d.png">

4. The Propose Circuit button collapses if the screen width is small:
<img width="1273" alt="Screen Shot 2020-04-09 at 10 15 43 AM" src="https://user-images.githubusercontent.com/14094978/78910883-24fe4180-7a4b-11ea-90c5-ca9473851524.png">
 

P.S The button currently does not work.
