### PR TITLE
Add circuit stats and input filter 

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -82,6 +82,8 @@ services:
     build:
       context: ..
       dockerfile: sapling-dev-server/Dockerfile
+      args:
+        PUBLIC_URL_PARTIAL: '/sapling-dev-server'
     container_name: sapling-dev-server-alpha
     expose:
       - 80
@@ -165,6 +167,8 @@ services:
     build:
       context: ..
       dockerfile: sapling-dev-server/Dockerfile
+      args:
+        PUBLIC_URL_PARTIAL: '/sapling-dev-server'
     container_name: sapling-dev-server-beta
     expose:
       - 80

--- a/sapling-dev-server/Dockerfile
+++ b/sapling-dev-server/Dockerfile
@@ -27,14 +27,19 @@ RUN git clone https://github.com/hyperledger/grid
 RUN cp -r grid/grid-ui/saplings/register-login /saplings
 RUN cp -r grid/grid-ui/saplings/profile /saplings
 
+ARG PUBLIC_URL_PARTIAL
+
+ENV PUBLIC_URL $PUBLIC_URL_PARTIAL
 RUN cd /saplings/register-login && \
   npm install && \
   npm run deploy
 
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/profile
 RUN cd /saplings/profile && \
   npm install && \
   npm run deploy
 
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/circuits
 RUN cd /saplings/circuits && \
   npm install && \
   npm run deploy

--- a/sapling-dev-server/userSaplings
+++ b/sapling-dev-server/userSaplings
@@ -3,10 +3,10 @@
     "displayName": "Circuits",
     "namespace": "circuits",
     "runtimeFiles": [
-      "localhost:3030/sapling-dev-server/circuits/js/circuits.js"
+      "localhost:3030/sapling-dev-server/circuits/static/js/circuits.js"
     ],
     "styleFiles": [
-      "localhost:3030/sapling-dev-server/circuits/css/circuits.css"
+      "localhost:3030/sapling-dev-server/circuits/static/css/circuits.css"
     ],
     "workerFiles": [],
     "icon": "http://localhost:3030/sapling-dev-server/circuits/images/circuits_logo.svg"

--- a/saplings/circuits/package.json
+++ b/saplings/circuits/package.json
@@ -35,6 +35,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",

--- a/saplings/circuits/package.json
+++ b/saplings/circuits/package.json
@@ -7,9 +7,10 @@
     "build": "node ./scripts/build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "add-to-canopy": "mkdir -p ../../sapling-dev-server/circuits && cp -r ./build/static/* ../../sapling-dev-server/circuits && cp -r images ../../sapling-dev-server/circuits",
+    "add-to-canopy": "mkdir -p ../../sapling-dev-server/circuits && cp -r ./build/static ../../sapling-dev-server/circuits && cp -r images ../../sapling-dev-server/circuits",
     "deploy": "npm run build && npm run add-to-canopy",
-    "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy",
+    "deploy-local": "PUBLIC_URL=/sapling-dev-server/circuits npm run deploy",
+    "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy-local",
     "lint": "eslint ."
   },
   "eslintConfig": {

--- a/saplings/circuits/src/App.js
+++ b/saplings/circuits/src/App.js
@@ -20,13 +20,18 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { library } from '@fortawesome/fontawesome-svg-core';
 
 import MainHeader from './components/MainHeader';
+import { LocalNodeProvider } from './state/localNode';
+import Content from './components/Content';
 
 library.add(faPlus);
 
 function App() {
   return (
     <div className="circuits-app">
-      <MainHeader />
+      <LocalNodeProvider>
+        <MainHeader />
+        <Content />
+      </LocalNodeProvider>
     </div>
   );
 }

--- a/saplings/circuits/src/api/requests.js
+++ b/saplings/circuits/src/api/requests.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function errorResponse(request, message) {
+  return {
+    ok: false,
+    status: request.status,
+    statusText: request.statusText,
+    headers: request.getAllResponseHeaders(),
+    data: message || request.responseText,
+    json: JSON.parse(message || request.responseText)
+  };
+}
+
+export function get(url) {
+  return new Promise(resolve => {
+    const request = new XMLHttpRequest();
+    request.open('GET', url, true);
+    request.timeout = 5000;
+
+    request.onload = () => {
+      return resolve({
+        ok: request.status >= 200 && request.status < 300,
+        status: request.status,
+        statusText: request.statusText,
+        headers: request.getAllResponseHeaders(),
+        data: request.responseText,
+        json: JSON.parse(request.responseText)
+      });
+    };
+
+    request.onError = () => {
+      resolve(errorResponse());
+    };
+
+    request.ontimeout = () => {
+      resolve(errorResponse(request, 'Request took longer than expected.'));
+    };
+
+    request.send();
+  });
+}

--- a/saplings/circuits/src/api/splinter.js
+++ b/saplings/circuits/src/api/splinter.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getSharedConfig } from 'splinter-saplingjs';
+import { get } from './requests';
+
+const { splinterURL } = getSharedConfig().canopyConfig;
+
+export const getNodeID = async () => {
+  const result = await get(`${splinterURL}/status`);
+
+  if (result.ok) {
+    return result.json.node_id;
+  }
+  throw Error(result.data);
+};

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -125,6 +125,32 @@ const Content = () => {
           }}
         />
       </div>
+      <div>
+        <table>
+          <tr>
+            <th>Circuit ID</th>
+            <th>Service count</th>
+            <th>Management Type</th>
+          </tr>
+          {circuitState.filteredCircuits.map(circuit => {
+            return (
+              <tr>
+                <td>{circuit.id}</td>
+                <td>
+                  {
+                    new Set(
+                      circuit.roster.map(service => {
+                        return service.service_type;
+                      })
+                    ).size
+                  }
+                </td>
+                <td>{circuit.managementType}</td>
+              </tr>
+            );
+          })}
+        </table>
+      </div>
     </div>
   );
 };

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -42,6 +42,43 @@ const circuitsReducer = (state, action) => {
       throw new Error(`unhandled action type: ${action.type}`);
   }
 };
+
+const filterCircuits = (circuits, filterBy) => {
+  if (filterBy.filterTerm.length === 0) {
+    return circuits;
+  }
+  const filteredCircuits = circuits.filter(circuit => {
+    if (circuit.id.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
+      return true;
+    }
+    if (
+      circuit.managementType.toLowerCase().indexOf(filterBy.filterTerm) > -1
+    ) {
+      return true;
+    }
+    if (circuit.comments.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
+      return true;
+    }
+    if (
+      circuit.members.filter(
+        member => member.toLowerCase().indexOf(filterBy.filterTerm) > -1
+      ).length > 0
+    ) {
+      return true;
+    }
+    if (
+      circuit.roster.filter(
+        service => service.service_type.indexOf(filterBy.filterTerm) > -1
+      ).length > 0
+    ) {
+      return true;
+    }
+    return false;
+  });
+
+  return filteredCircuits;
+};
+
 const Content = () => {
   const circuits = processCircuits(mockCircuits.concat(mockProposals));
 
@@ -73,6 +110,20 @@ const Content = () => {
             {actionRequired > 1 ? 'Actions required' : 'Action required'}
           </div>
         </div>
+        <input
+          className="filterTable"
+          type="text"
+          placeholder="Filter"
+          onKeyUp={event => {
+            circuitsDispatch({
+              type: 'filter',
+              filterCircuits,
+              filter: {
+                filterTerm: event.target.value.toLowerCase()
+              }
+            });
+          }}
+        />
       </div>
     </div>
   );

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useReducer } from 'react';
+import { useLocalNodeState } from '../state/localNode';
+import mockCircuits from '../mockData/mockCircuits';
+import mockProposals from '../mockData/mockProposals';
+import { processCircuits } from '../data/processCircuits';
+
+import './Content.scss';
+
+const circuitsReducer = (state, action) => {
+  switch (action.type) {
+    case 'sort': {
+      const sortedCircuits = action.sortCircuits(
+        state.filteredCircuits,
+        action.sort
+      );
+      return { ...state, filteredCircuits: sortedCircuits };
+    }
+    case 'filter': {
+      const filteredCircuits = action.filterCircuits(
+        state.circuits,
+        action.filter
+      );
+      return { ...state, filteredCircuits };
+    }
+    default:
+      throw new Error(`unhandled action type: ${action.type}`);
+  }
+};
+const Content = () => {
+  const circuits = processCircuits(mockCircuits.concat(mockProposals));
+
+  const [circuitState, circuitsDispatch] = useReducer(circuitsReducer, {
+    circuits,
+    filteredCircuits: circuits
+  });
+  const nodeID = useLocalNodeState();
+  const totalCircuits = circuitState.circuits.length;
+  let actionRequired = 0;
+  if (nodeID !== 'unknown') {
+    actionRequired = circuitState.circuits.filter(circuit =>
+      circuit.actionRequired(nodeID)
+    ).length;
+  }
+
+  return (
+    <div className="main-content">
+      <div className="midContent">
+        <div className="circuit-stats">
+          <div className="stat total-circuits">
+            <span className="stat-count circuits-count">{totalCircuits}</span>
+            Circuits
+          </div>
+          <div className="stat action-required">
+            <span className="stat-count action-required-count">
+              {actionRequired}
+            </span>
+            {actionRequired > 1 ? 'Actions required' : 'Action required'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Content;

--- a/saplings/circuits/src/components/Content.scss
+++ b/saplings/circuits/src/components/Content.scss
@@ -26,6 +26,18 @@
     flex-direction: row;
     justify-content: space-between;
 
+    .filterTable {
+      border: none;
+      border-bottom: 1px solid var(--color-grey);
+      padding: 1rem 0 0.5rem 2rem;
+      background-image: url('../images/search_icon.svg');
+      background-position: 5px 15px;
+      background-repeat: no-repeat;
+      background-size: 1rem;
+      font-size: 1rem;
+      width: 15rem;
+    }
+
     .circuit-stats {
       display: flex;
       flex-direction: row;
@@ -59,6 +71,11 @@
   .main-content {
     .midContent {
       flex-direction: column;
+
+       .filterTable {
+         margin-top: 1rem;
+         width: auto;
+       }
 
       .circuit-stats {
         .stat {

--- a/saplings/circuits/src/components/Content.scss
+++ b/saplings/circuits/src/components/Content.scss
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.main-content {
+  color: var(--color-dark-grey);
+  display: flex;
+  flex-direction: column;
+  margin: 2.5rem 3rem 0 3rem;
+  max-height: 75%;
+
+  .midContent {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    .circuit-stats {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-around;
+
+      .stat {
+        display: flex;
+        margin-right: 2rem;
+        flex-direction: row;
+        justify-content: space-between;;
+        align-items: center;
+
+        .stat-count {
+          font-size: 2rem;
+          margin-right: 0.5rem;
+        }
+
+        .circuits-count {
+          color: var(--color-secondary);
+        }
+
+        .action-required-count {
+          color: var(--color-attention);
+        }
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .main-content {
+    .midContent {
+      flex-direction: column;
+
+      .circuit-stats {
+        .stat {
+          margin-right: 1rem;
+
+          .stat-count {
+            font-size: 1rem;
+          }
+        }
+      }
+    }
+  }
+}

--- a/saplings/circuits/src/components/MainHeader.scss
+++ b/saplings/circuits/src/components/MainHeader.scss
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 3rem;
+  margin: 2rem 3rem 0rem 3rem;
 
   .circuits-title {
     color: var(--color-grey);

--- a/saplings/circuits/src/data/processCircuits.js
+++ b/saplings/circuits/src/data/processCircuits.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function Circuit(data) {
+  if (data.proposal_type) {
+    this.id = data.circuit_id;
+    this.status = 'Pending';
+    this.members = data.circuit.members.map(member => {
+      return member.node_id;
+    });
+    this.roster = data.circuit.roster;
+    this.managementType = data.circuit.management_type;
+    this.applicationMetadata = data.circuit.application_metadata;
+    this.comments = data.circuit.comments;
+    this.proposal = {
+      votes: data.votes,
+      requester: data.requester,
+      requesterNodeID: data.requester_node_id,
+      proposalType: data.proposal_type
+    };
+  } else {
+    this.id = data.id;
+    this.status = 'Active';
+    this.members = data.members;
+    this.roster = data.roster;
+    this.managementType = data.management_type;
+    this.applicationMetadata = data.application_metadata;
+    this.comments = 'N/A';
+    this.proposal = {
+      votes: [],
+      requester: '',
+      requesterNodeID: '',
+      proposalType: ''
+    };
+  }
+}
+
+function awaitingApproval() {
+  if (this.status === 'Pending') {
+    return true;
+  }
+  return false;
+}
+
+function actionRequired(nodeID) {
+  const nodeHasVoted =
+    this.proposal.votes.filter(vote => {
+      return vote.voter_node_id === nodeID;
+    }).length > 0;
+
+  if (this.awaitingApproval() && !nodeHasVoted) {
+    return true;
+  }
+  return false;
+}
+
+Circuit.prototype.awaitingApproval = awaitingApproval;
+Circuit.prototype.actionRequired = actionRequired;
+
+const processCircuits = circuits => {
+  return circuits.map(item => {
+    return new Circuit(item);
+  });
+};
+
+export { processCircuits, Circuit };

--- a/saplings/circuits/src/images/search_icon.svg
+++ b/saplings/circuits/src/images/search_icon.svg
@@ -1,0 +1,20 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<svg width="25" height="26" viewBox="0 0 25 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="1.93595" height="17.8379" transform="matrix(0.715643 0.698466 -0.707407 0.706806 12.6187 11.4875)" fill="#555555"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3296 15.6156C21.5659 15.6156 25.0001 12.1199 25.0001 7.80781C25.0001 3.49567 21.5659 0 17.3296 0C13.0934 0 9.65918 3.49567 9.65918 7.80781C9.65918 12.1199 13.0934 15.6156 17.3296 15.6156ZM17.3296 13.013C20.1538 13.013 22.4433 10.6826 22.4433 7.80781C22.4433 4.93305 20.1538 2.6026 17.3296 2.6026C14.5055 2.6026 12.216 4.93305 12.216 7.80781C12.216 10.6826 14.5055 13.013 17.3296 13.013Z" fill="#555555"/>
+</svg>

--- a/saplings/circuits/src/mockData/mockCircuits.js
+++ b/saplings/circuits/src/mockData/mockCircuits.js
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default [
+  {
+    id: 'WBh1C-MIcIK',
+    members: ['alpha-node-000', 'beta-node-000'],
+    roster: [
+      {
+        service_id: 'JWrS',
+        service_type: 'scabbard',
+        allowed_nodes: ['alpha-node-000'],
+        arguments: {
+          peer_services: ['rOF6'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'rOF6',
+        service_type: 'scabbard',
+        allowed_nodes: ['beta-node-000'],
+        arguments: {
+          peer_services: ['JWrS'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      }
+    ],
+    management_type: 'gameroom',
+    application_metadata: ''
+  },
+  {
+    id: 'j64jw-QUi5K',
+    members: [
+      'alpha-node-000',
+      'beta-node-000',
+      'gamma-node-000',
+      'delta-node-000',
+      'epsilon-node-000',
+      'zeta-node-000',
+      'eta-node-000',
+      'theta-node-000'
+    ],
+    roster: [
+      {
+        service_id: 'b5ED',
+        service_type: 'scabbard',
+        allowed_nodes: ['alpha-node-000'],
+        arguments: {
+          peer_services: ['DI91, ruP2, oUwo, RNM4, 9dw0, yHE4, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'DI91',
+        service_type: 'scabbard',
+        allowed_nodes: ['beta-node-000'],
+        arguments: {
+          peer_services: ['b5ED, ruP2, oUwo, RNM4, 9dw0, yHE4, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'ruP2',
+        service_type: 'scabbard',
+        allowed_nodes: ['gamma-node-000'],
+        arguments: {
+          peer_services: ['b5ED, DI91, oUwo, RNM4, 9dw0, yHE4, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'oUwo',
+        service_type: 'scabbard',
+        allowed_nodes: ['delta-node-000'],
+        arguments: {
+          peer_services: ['b5ED, DI91, ruP2, RNM4, 9dw0, yHE4, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'RNM4',
+        service_type: 'scabbard',
+        allowed_nodes: ['epsilon-node-000'],
+        arguments: {
+          peer_services: ['b5ED, DI91, ruP2, oUwo, 9dw0, yHE4, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: '9dw0',
+        service_type: 'scabbard',
+        allowed_nodes: ['zeta-node-000'],
+        arguments: {
+          peer_services: ['b5ED, DI91, ruP2, oUwo, RNM4, yHE4, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'yHE4',
+        service_type: 'scabbard',
+        allowed_nodes: ['eta-node-000'],
+        arguments: {
+          peer_services: ['b5ED, DI91, ruP2, oUwo, RNM4, 9dw0, zmgU'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'zmgU',
+        service_type: 'scabbard',
+        allowed_nodes: ['theta-node-000'],
+        arguments: {
+          peer_services: ['b5ED, DI91, ruP2, oUwo, RNM4, 9dw0, yHE4'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'S0Pi',
+        service_type: 'private-xo',
+        allowed_nodes: ['alpha-node-000'],
+        arguments: {}
+      }
+    ],
+    management_type: 'grid',
+    application_metadata: ''
+  },
+  {
+    id: 'vwXDB-aHBpR',
+    members: ['alpha-node-000', 'beta-node-000'],
+    roster: [
+      {
+        service_id: '4k0f',
+        service_type: 'scabbard',
+        allowed_nodes: ['alpha-node-000'],
+        arguments: {
+          peer_services: ['d4He'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'd4He',
+        service_type: 'scabbard',
+        allowed_nodes: ['beta-node-000'],
+        arguments: {
+          peer_services: ['4k0f'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      }
+    ],
+    management_type: 'default',
+    application_metadata: ''
+  },
+  {
+    id: 'pqGUt-8rSS9',
+    members: ['alpha-node-000', 'beta-node-000'],
+    roster: [
+      {
+        service_id: 'jYQt',
+        service_type: 'scabbard',
+        allowed_nodes: ['alpha-node-000'],
+        arguments: {
+          peer_services: ['qQ5k'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      },
+      {
+        service_id: 'qQ5k',
+        service_type: 'scabbard',
+        allowed_nodes: ['beta-node-000'],
+        arguments: {
+          peer_services: ['jYQt'],
+          admin_keys: [
+            '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+          ]
+        }
+      }
+    ],
+    management_type: 'gameroom',
+    application_metadata: ''
+  }
+];

--- a/saplings/circuits/src/mockData/mockProposals.js
+++ b/saplings/circuits/src/mockData/mockProposals.js
@@ -1,0 +1,417 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default [
+  {
+    proposal_type: 'Create',
+    circuit_id: 'uI2jb-JtA9s',
+    circuit_hash:
+      '8ce518770b962429a953b10220905ac9adf86a855f0b085695f444edf991b8ca',
+    circuit: {
+      circuit_id: 'uI2jb-JtA9s',
+      members: [
+        {
+          node_id: 'alpha-node-000',
+          endpoint: 'tls://splinterd-alpha:8044'
+        },
+        {
+          node_id: 'beta-node-000',
+          endpoint: 'tls://splinterd-beta:8044'
+        }
+      ],
+      roster: [
+        {
+          service_id: 'FGHI',
+          service_type: 'scabbard',
+          allowed_nodes: ['alpha-node-000'],
+          arguments: {
+            peer_services: ['JKLM'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'JKLM',
+          service_type: 'scabbard',
+          allowed_nodes: ['beta-node-000'],
+          arguments: {
+            peer_services: ['FGHI'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        }
+      ],
+      management_type: 'gameroom',
+      application_metadata:
+        '7b2273636162626172645f61646d696e5f6b657973223a5b223',
+      comments: 'Alpha/Beta Circuit'
+    },
+    votes: [
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'alpha-node-000'
+      }
+    ],
+    requester:
+      '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+    requester_node_id: 'alpha-node-000'
+  },
+  {
+    proposal_type: 'Create',
+    circuit_id: '6MNri-wRJ7B',
+    circuit_hash:
+      '8ce518770b962429a953b10220905ac9adf86a855f0b085695f444edf991b8ca',
+    circuit: {
+      circuit_id: '6MNri-wRJ7B',
+      members: [
+        {
+          node_id: 'alpha-node-000',
+          endpoint: 'tls://splinterd-alpha:8044'
+        },
+        {
+          node_id: 'beta-node-000',
+          endpoint: 'tls://splinterd-beta:8044'
+        },
+        {
+          node_id: 'gamma-node-000',
+          endpoint: 'tls://splinterd-alpha:8044'
+        },
+        {
+          node_id: 'delta-node-000',
+          endpoint: 'tls://splinterd-delta:8044'
+        },
+        {
+          node_id: 'epsilon-node-000',
+          endpoint: 'tls://splinterd-epsilon:8044'
+        },
+        {
+          node_id: 'zeta-node-000',
+          endpoint: 'tls://splinterd-zeta:8044'
+        },
+        {
+          node_id: 'eta-node-000',
+          endpoint: 'tls://splinterd-eta:8044'
+        },
+        {
+          node_id: 'theta-node-000',
+          endpoint: 'tls://splinterd-theta:8044'
+        }
+      ],
+      roster: [
+        {
+          service_id: 'd7tp',
+          service_type: 'scabbard',
+          allowed_nodes: ['alpha-node-000'],
+          arguments: {
+            peer_services: ['OBzl, LAaH, xi7n, qXNp, hsq9, Lii6, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'OBzl',
+          service_type: 'scabbard',
+          allowed_nodes: ['beta-node-000'],
+          arguments: {
+            peer_services: ['d7tp, LAaH, xi7n, qXNp, hsq9, Lii6, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'LAaH',
+          service_type: 'scabbard',
+          allowed_nodes: ['gamma-node-000'],
+          arguments: {
+            peer_services: ['d7tp, OBzl, xi7n, qXNp, hsq9, Lii6, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'xi7n',
+          service_type: 'scabbard',
+          allowed_nodes: ['delta-node-000'],
+          arguments: {
+            peer_services: ['d7tp, OBzl, LAaH, qXNp, hsq9, Lii6, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'qXNp',
+          service_type: 'scabbard',
+          allowed_nodes: ['epsilon-node-000'],
+          arguments: {
+            peer_services: ['d7tp, OBzl, LAaH, xi7n, hsq9, Lii6, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'hsq9',
+          service_type: 'scabbard',
+          allowed_nodes: ['zeta-node-000'],
+          arguments: {
+            peer_services: ['d7tp, OBzl, LAaH, xi7n, qXNp, Lii6, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'Lii6',
+          service_type: 'scabbard',
+          allowed_nodes: ['eta-node-000'],
+          arguments: {
+            peer_services: ['d7tp, OBzl, LAaH, xi7n, qXNp, hsq9, wmCp'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'wmCp',
+          service_type: 'scabbard',
+          allowed_nodes: ['theta-node-000'],
+          arguments: {
+            peer_services: ['d7tp, OBzl, LAaH, xi7n, qXNp, hsq9, Lii6'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'DMWU',
+          service_type: 'private-xo',
+          allowed_nodes: ['alpha-node-000'],
+          arguments: {}
+        }
+      ],
+      management_type: 'grid',
+      application_metadata:
+        '7b2273636162626172645f61646d696e5f6b657973223a5b223',
+      comments:
+        'Greek Alphabet Consortium: \n This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal. This is a long comment describing this proposal.'
+    },
+    votes: [
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'beta-node-000'
+      },
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'gamma-node-000'
+      },
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'delta-node-000'
+      }
+    ],
+    requester:
+      '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+    requester_node_id: 'beta-node-000'
+  },
+  {
+    proposal_type: 'Create',
+    circuit_id: 'S0cJ6-Z3Gb8',
+    circuit_hash:
+      '8ce518770b962429a953b10220905ac9adf86a855f0b085695f444edf991b8ca',
+    circuit: {
+      circuit_id: 'S0cJ6-Z3Gb8',
+      members: [
+        {
+          node_id: 'alpha-node-000',
+          endpoint: 'tls://splinterd-alpha:8044'
+        },
+        {
+          node_id: 'beta-node-000',
+          endpoint: 'tls://splinterd-beta:8044'
+        }
+      ],
+      roster: [
+        {
+          service_id: 'LklR',
+          service_type: 'scabbard',
+          allowed_nodes: ['alpha-node-000'],
+          arguments: {
+            peer_services: ['GLnW'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'GLnW',
+          service_type: 'scabbard',
+          allowed_nodes: ['beta-node-000'],
+          arguments: {
+            peer_services: ['LklR'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        }
+      ],
+      management_type: 'gameroom',
+      application_metadata:
+        '7b2273636162626172645f61646d696e5f6b657973223a5b223',
+      comments: 'Test Circuit'
+    },
+    votes: [
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'beta-node-000'
+      }
+    ],
+    requester:
+      '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+    requester_node_id: 'beta-node-000'
+  },
+  {
+    proposal_type: 'Create',
+    circuit_id: '2LeHR-rKeX7',
+    circuit_hash:
+      '8ce518770b962429a953b10220905ac9adf86a855f0b085695f444edf991b8ca',
+    circuit: {
+      circuit_id: '2LeHR-rKeX7',
+      members: [
+        {
+          node_id: 'alpha-node-000',
+          endpoint: 'tls://splinterd-alpha:8044'
+        },
+        {
+          node_id: 'beta-node-000',
+          endpoint: 'tls://splinterd-beta:8044'
+        }
+      ],
+      roster: [
+        {
+          service_id: '59YP',
+          service_type: 'scabbard',
+          allowed_nodes: ['alpha-node-000'],
+          arguments: {
+            peer_services: ['m8l1'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'm8l1',
+          service_type: 'scabbard',
+          allowed_nodes: ['beta-node-000'],
+          arguments: {
+            peer_services: ['59YP'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        }
+      ],
+      management_type: 'grid',
+      application_metadata:
+        '7b2273636162626172645f61646d696e5f6b657973223a5b223',
+      comments: 'Grid Test Circuit'
+    },
+    votes: [
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'alpha-node-000'
+      }
+    ],
+    requester:
+      '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+    requester_node_id: 'alpha-node-000'
+  },
+  {
+    proposal_type: 'Create',
+    circuit_id: 'IK6Nt-8vG49',
+    circuit_hash:
+      '8ce518770b962429a953b10220905ac9adf86a855f0b085695f444edf991b8ca',
+    circuit: {
+      circuit_id: 'IK6Nt-8vG49',
+      members: [
+        {
+          node_id: 'alpha-node-000',
+          endpoint: 'tls://splinterd-alpha:8044'
+        },
+        {
+          node_id: 'beta-node-000',
+          endpoint: 'tls://splinterd-beta:8044'
+        }
+      ],
+      roster: [
+        {
+          service_id: 'yBuC',
+          service_type: 'scabbard',
+          allowed_nodes: ['alpha-node-000'],
+          arguments: {
+            peer_services: ['d6od'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        },
+        {
+          service_id: 'd6od',
+          service_type: 'scabbard',
+          allowed_nodes: ['beta-node-000'],
+          arguments: {
+            peer_services: ['yBuC'],
+            admin_keys: [
+              '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169'
+            ]
+          }
+        }
+      ],
+      management_type: 'defaut',
+      application_metadata:
+        '7b2273636162626172645f61646d696e5f6b657973223a5b223',
+      comments: 'Circuit Test 001'
+    },
+    votes: [
+      {
+        public_key:
+          '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+        vote: 'Accept',
+        voter_node_id: 'alpha-node-000'
+      }
+    ],
+    requester:
+      '026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118',
+    requester_node_id: 'alpha-node-000'
+  }
+];

--- a/saplings/circuits/src/state/localNode.js
+++ b/saplings/circuits/src/state/localNode.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getNodeID } from '../api/splinter';
+
+const LocalNodeContext = React.createContext();
+
+function LocalNodeProvider({ children }) {
+  const [nodeState, setNodeID] = useState({ isSet: false, nodeID: 'unknown' });
+  useEffect(() => {
+    const getNode = async () => {
+      if (!nodeState.isSet) {
+        try {
+          const node = await getNodeID();
+          setNodeID({ isSet: true, nodeID: node });
+        } catch (e) {
+          throw Error(`Error fetching node information: ${e}`);
+        }
+      }
+    };
+    getNode();
+  });
+
+  return (
+    <LocalNodeContext.Provider value={nodeState.nodeID}>
+      {children}
+    </LocalNodeContext.Provider>
+  );
+}
+
+LocalNodeProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+function useLocalNodeState() {
+  const context = React.useContext(LocalNodeContext);
+  if (context === undefined) {
+    throw new Error(
+      'useLocalNodeState must be used within a LocalNodeProvider'
+    );
+  }
+  return context;
+}
+
+export { LocalNodeProvider, useLocalNodeState };


### PR DESCRIPTION
This PR adds: 
 - Logic to fetch the local node ID from the splinter API
 - Logic to process circuit and proposal data coming from the API
 - Mock data for circuits and proposals
 - Adds an input filter for filtering circuits shown
 - Adds summary stats to the top of the page

#### To test

1. Run 
```
docker-compose -f docker/docker-compose.yaml up --build
```
2. To see the alpha node UI go to: `localhost:3030`

3. Click on the `circuits` option in the left side menu, it will forward you to  `localhost:3030/circuits`: 
<img width="1196" alt="Screen Shot 2020-04-14 at 1 53 40 PM" src="https://user-images.githubusercontent.com/14094978/79262730-603bae80-7e57-11ea-9b73-e046df5dfeba.png">

4. Test the filter input. You can filter by ID, management type, service type, members and comments. The full data can be found at `saplings/circuits/src/mockData/mockCircuits.js` and `saplings/circuits/src/mockData/mockProposals.js`.

5. To see the beta node UI go to: `localhost:3031`

6. Click on the `circuits` option in the left side menu, it will forward you to  `localhost:3031/circuits`: 
 
<img width="1196" alt="Screen Shot 2020-04-14 at 2 13 54 PM" src="https://user-images.githubusercontent.com/14094978/79264471-4059ba00-7e5a-11ea-9d55-f7c95dee371f.png">


Notice that  in the beta node UI the count of circuits with action required shows `3` while in the alpha node it shows `2`. That's because that are 3 circuits proposals the beta node needs to vote on, and 2 circuits proposals that the alpha node needs to vote on. 

P.S This PR seems big, but 600+ lines are just mock data added for tests purposes and will be removed soon. They don't require careful review. 


