### PR TITLE
Upgrade docker-compose for the removal of --transport in splinterd

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -54,11 +54,10 @@ services:
         splinterd -vv \
         --registry file:///configs/nodes.yaml \
         --bind 0.0.0.0:8085 \
-        --network-endpoint 0.0.0.0:8044 \
+        --network-endpoint tcps://0.0.0.0:8044 \
         --node-id alpha-node-000 \
-        --service-endpoint 0.0.0.0:8043 \
+        --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --transport tls \
         --client-cert /etc/splinter/certs/client.crt \
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \
@@ -137,11 +136,10 @@ services:
         splinterd -vv \
         --registry file:///configs/nodes.yaml \
         --bind 0.0.0.0:8085 \
-        --network-endpoint 0.0.0.0:8044 \
+        --network-endpoint tcps://0.0.0.0:8044 \
         --node-id beta-node-000 \
-        --service-endpoint 0.0.0.0:8043 \
+        --service-endpoint tcp://0.0.0.0:8043 \
         --storage yaml \
-        --transport tls \
         --client-cert /etc/splinter/certs/client.crt \
         --client-key /etc/splinter/certs/private/client.key \
         --server-cert /etc/splinter/certs/server.crt \


### PR DESCRIPTION
Upgrades to work with the new version of splinterd
after this change https://github.com/Cargill/splinter/pull/711

This should be merged after https://github.com/Cargill/splinter/pull/711.