### PR TITLE
Add circuits table

### DIFF
--- a/app/src/theme/colors.scss
+++ b/app/src/theme/colors.scss
@@ -30,6 +30,7 @@ $color-secondary-dark: darken($color-secondary, 15%);
   --color-secondary-dark: #{$color-secondary-dark};
   --color-dark-grey: #333333;
   --color-grey: #555555;
+  --color-light-grey: #DDDDDD;
   --color-attention: #d94f4f;
   --color-text-on-dark: rgba(255, 255, 255, 0.9);
   --color-text-light-on-dark: rgba(255, 255, 255, 0.7);

--- a/saplings/circuits/src/App.js
+++ b/saplings/circuits/src/App.js
@@ -20,7 +20,12 @@ import {
   faPlus,
   faCaretUp,
   faCaretDown,
-  faSort
+  faExclamation,
+  faFilter,
+  faSort,
+  faExclamationCircle,
+  faBusinessTime,
+  faCheck
 } from '@fortawesome/free-solid-svg-icons';
 import { library } from '@fortawesome/fontawesome-svg-core';
 
@@ -28,7 +33,17 @@ import MainHeader from './components/MainHeader';
 import { LocalNodeProvider } from './state/localNode';
 import Content from './components/Content';
 
-library.add(faPlus, faCaretUp, faCaretDown, faSort);
+library.add(
+  faPlus,
+  faCaretUp,
+  faCaretDown,
+  faExclamation,
+  faFilter,
+  faSort,
+  faExclamationCircle,
+  faBusinessTime,
+  faCheck
+);
 
 function App() {
   return (

--- a/saplings/circuits/src/App.js
+++ b/saplings/circuits/src/App.js
@@ -16,14 +16,19 @@
 
 import React from 'react';
 import './App.css';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import {
+  faPlus,
+  faCaretUp,
+  faCaretDown,
+  faSort
+} from '@fortawesome/free-solid-svg-icons';
 import { library } from '@fortawesome/fontawesome-svg-core';
 
 import MainHeader from './components/MainHeader';
 import { LocalNodeProvider } from './state/localNode';
 import Content from './components/Content';
 
-library.add(faPlus);
+library.add(faPlus, faCaretUp, faCaretDown, faSort);
 
 function App() {
   return (

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -14,78 +14,15 @@
  * limitations under the License.
  */
 
-import React, { useReducer } from 'react';
+import React from 'react';
 import { useLocalNodeState } from '../state/localNode';
-import mockCircuits from '../mockData/mockCircuits';
-import mockProposals from '../mockData/mockProposals';
-import { processCircuits } from '../data/processCircuits';
+import { useCircuitsState } from '../state/circuits';
 
 import './Content.scss';
 
-const circuitsReducer = (state, action) => {
-  switch (action.type) {
-    case 'sort': {
-      const sortedCircuits = action.sortCircuits(
-        state.filteredCircuits,
-        action.sort
-      );
-      return { ...state, filteredCircuits: sortedCircuits };
-    }
-    case 'filter': {
-      const filteredCircuits = action.filterCircuits(
-        state.circuits,
-        action.filter
-      );
-      return { ...state, filteredCircuits };
-    }
-    default:
-      throw new Error(`unhandled action type: ${action.type}`);
-  }
-};
-
-const filterCircuits = (circuits, filterBy) => {
-  if (filterBy.filterTerm.length === 0) {
-    return circuits;
-  }
-  const filteredCircuits = circuits.filter(circuit => {
-    if (circuit.id.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
-      return true;
-    }
-    if (
-      circuit.managementType.toLowerCase().indexOf(filterBy.filterTerm) > -1
-    ) {
-      return true;
-    }
-    if (circuit.comments.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
-      return true;
-    }
-    if (
-      circuit.members.filter(
-        member => member.toLowerCase().indexOf(filterBy.filterTerm) > -1
-      ).length > 0
-    ) {
-      return true;
-    }
-    if (
-      circuit.roster.filter(
-        service => service.service_type.indexOf(filterBy.filterTerm) > -1
-      ).length > 0
-    ) {
-      return true;
-    }
-    return false;
-  });
-
-  return filteredCircuits;
-};
-
 const Content = () => {
-  const circuits = processCircuits(mockCircuits.concat(mockProposals));
+  const [circuitState, circuitsDispatch] = useCircuitsState();
 
-  const [circuitState, circuitsDispatch] = useReducer(circuitsReducer, {
-    circuits,
-    filteredCircuits: circuits
-  });
   const nodeID = useLocalNodeState();
   const totalCircuits = circuitState.circuits.length;
   let actionRequired = 0;
@@ -117,7 +54,6 @@ const Content = () => {
           onKeyUp={event => {
             circuitsDispatch({
               type: 'filter',
-              filterCircuits,
               filter: {
                 filterTerm: event.target.value.toLowerCase()
               }

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -55,7 +55,7 @@ const Content = () => {
           placeholder="Filter"
           onKeyUp={event => {
             circuitsDispatch({
-              type: 'filter',
+              type: 'filterByTerm',
               filter: {
                 filterTerm: event.target.value.toLowerCase()
               }

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -18,6 +18,8 @@ import React from 'react';
 import { useLocalNodeState } from '../state/localNode';
 import { useCircuitsState } from '../state/circuits';
 
+import CircuitsTable from './circuitsTable/Table';
+
 import './Content.scss';
 
 const Content = () => {
@@ -61,36 +63,10 @@ const Content = () => {
           }}
         />
       </div>
-      <div>
-        <table>
-          <thead>
-            <tr>
-              <th>Circuit ID</th>
-              <th>Service count</th>
-              <th>Management Type</th>
-            </tr>
-          </thead>
-          <tbody>
-            {circuitState.filteredCircuits.map(circuit => {
-              return (
-                <tr key={circuit.id}>
-                  <td>{circuit.id}</td>
-                  <td>
-                    {
-                      new Set(
-                        circuit.roster.map(service => {
-                          return service.service_type;
-                        })
-                      ).size
-                    }
-                  </td>
-                  <td>{circuit.managementType}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+      <CircuitsTable
+        circuits={circuitState.filteredCircuits}
+        dispatch={circuitsDispatch}
+      />
     </div>
   );
 };

--- a/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
+++ b/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
@@ -21,5 +21,37 @@
   .circuits-table {
     width: 100%;
     border-collapse: collapse;
+
+    th, td {
+      border-bottom: 1px solid var(--color-light-grey);
+      padding: 2rem 2rem 2rem 0;
+      max-width: 13rem;
+    }
+
+    .table-header th {
+      color: var(--color-grey);
+      font-weight: 100;
+      font-size: 10pt;
+      text-align: left;
+      cursor: pointer;
+      padding-bottom: 1rem;
+      background-color: var(--background-color-white);
+      box-shadow: 0 4px 4px -4px rgba(0,0,0,.25);
+      position: -webkit-sticky;
+      position: sticky;
+      top:0;
+
+      .caret {
+        margin-left: 0.3rem;
+        font-size: 8pt;
+      }
+    }
+    .text-highlight {
+      color: var(--color-secondary)
+    }
+
+    .text-grey {
+      color: var(--color-light-grey)
+    }
   }
 }

--- a/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
+++ b/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
@@ -132,5 +132,35 @@
     .text-grey {
       color: var(--color-light-grey)
     }
+
+    .table-row {
+      td, .proposal-status {
+        font-size: 0.8rem;
+        vertical-align: middle;
+      }
+
+      .proposal-status {
+        display: flex;
+        flex-direction: column;
+
+        .status {
+          margin-top: 0.5rem;
+          font-size: inherit;
+
+          .status-icon {
+            margin-left: 0.5rem;
+          }
+        }
+      }
+
+      .circuit-comment {
+          overflow: hidden;
+          max-width: 13rem;
+          max-height: 5rem;
+          display: -webkit-box;
+          -webkit-line-clamp: 5; /* number of lines to show */
+          -webkit-box-orient: vertical;
+      }
+    }
   }
 }

--- a/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
+++ b/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+.table-container {
+  overflow:auto;
+  margin-top: 3rem;
+
+  .circuits-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+}

--- a/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
+++ b/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
@@ -31,7 +31,7 @@
     .table-header th {
       color: var(--color-grey);
       font-weight: 100;
-      font-size: 10pt;
+      font-size: 0.8rem;
       text-align: left;
       cursor: pointer;
       padding-bottom: 1rem;
@@ -43,9 +43,88 @@
 
       .caret {
         margin-left: 0.3rem;
-        font-size: 8pt;
+        font-size: 0.5rem;
       }
     }
+
+    .status-dropdown {
+      position: relative;
+      display: inline-block;
+      width: 100%;
+      padding: 0;
+
+      button {
+        background-color: transparent;
+        border: none;
+        color: inherit;
+        font-weight: inherit;
+        font-size: inherit;
+        letter-spacing: inherit;
+        width: 100%;
+        height: 100%;
+        text-align: left;
+        cursor: pointer;
+      }
+
+      button:focus {
+        outline: none
+      }
+
+      .filterStatus {
+        margin-top: 1rem;
+        display: none;
+        position: absolute;
+        z-index: 1;
+        background-color: var(--background-color-white);
+        width: 12rem;
+        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+        left: auto;
+        right: 0;
+
+        .status-icon {
+          font-size: 0.8rem;
+          margin-right: 0.5rem;
+        }
+        .hidden {
+          visibility: hidden;
+        }
+        .apply-filter-btn {
+          text-align: center;
+          color: var(--color-secondary);
+          border: 1px solid var(--color-secondary-light);
+          padding: 0.3rem;
+        }
+      }
+
+      .filterStatus.show {
+        display: block;
+      }
+
+      .statusOptions {
+        display: flex;
+        flex-direction: column;
+
+        .filterOption {
+          padding: 0.5rem;
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+        }
+
+        .filterOption:hover {
+          background-color: var(--color-light-grey);
+        }
+      }
+    }
+
+    .action-required {
+      color: var(--color-attention);
+    }
+
+    .awaiting-approval {
+      color: var(--color-secondary)
+    }
+
     .text-highlight {
       color: var(--color-secondary)
     }

--- a/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
+++ b/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
@@ -22,6 +22,14 @@
     width: 100%;
     border-collapse: collapse;
 
+    td.no-circuits-msg {
+      width: 100%;
+      min-height: 20%;
+      text-align: center;
+      color: var(--color-light-grey);
+      font-size: 2rem;      
+    }
+
     th, td {
       border-bottom: 1px solid var(--color-light-grey);
       padding: 2rem 2rem 2rem 0;

--- a/saplings/circuits/src/components/circuitsTable/Table.js
+++ b/saplings/circuits/src/components/circuitsTable/Table.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Circuit } from '../../data/processCircuits';
+import './CircuitsTable.scss';
+
+const CircuitsTable = ({ circuits, dispatch }) => {
+  return (
+    <div className="table-container">
+      <table className="circuits-table">
+      </table>
+    </div>
+  );
+};
+
+CircuitsTable.propTypes = {
+  circuits: PropTypes.arrayOf(Circuit).isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+export default CircuitsTable;

--- a/saplings/circuits/src/components/circuitsTable/Table.js
+++ b/saplings/circuits/src/components/circuitsTable/Table.js
@@ -23,10 +23,18 @@ import TableHeader from './TableHeader';
 import './CircuitsTable.scss';
 
 const CircuitsTable = ({ circuits, dispatch }) => {
+  const noCircuits = (
+    <tr>
+      <td colSpan="5" className="no-circuits-msg">
+        No circuits found
+      </td>
+    </tr>
+  );
   return (
     <div className="table-container">
       <table className="circuits-table">
         <TableHeader dispatch={dispatch} circuits={circuits} />
+        {circuits.length === 0 ? noCircuits : ''}
         {circuits.map(item => {
           return <TableRow circuit={item} />;
         })}

--- a/saplings/circuits/src/components/circuitsTable/Table.js
+++ b/saplings/circuits/src/components/circuitsTable/Table.js
@@ -17,12 +17,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Circuit } from '../../data/processCircuits';
+import TableHeader from './TableHeader';
+
 import './CircuitsTable.scss';
 
 const CircuitsTable = ({ circuits, dispatch }) => {
   return (
     <div className="table-container">
       <table className="circuits-table">
+        <TableHeader dispatch={dispatch} circuits={circuits} />
       </table>
     </div>
   );

--- a/saplings/circuits/src/components/circuitsTable/Table.js
+++ b/saplings/circuits/src/components/circuitsTable/Table.js
@@ -17,6 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Circuit } from '../../data/processCircuits';
+import TableRow from './TableRow';
 import TableHeader from './TableHeader';
 
 import './CircuitsTable.scss';
@@ -26,6 +27,9 @@ const CircuitsTable = ({ circuits, dispatch }) => {
     <div className="table-container">
       <table className="circuits-table">
         <TableHeader dispatch={dispatch} circuits={circuits} />
+        {circuits.map(item => {
+          return <TableRow circuit={item} />;
+        })}
       </table>
     </div>
   );

--- a/saplings/circuits/src/components/circuitsTable/TableHeader.js
+++ b/saplings/circuits/src/components/circuitsTable/TableHeader.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { Circuit } from '../../data/processCircuits';
+
+const TableHeader = ({ dispatch, circuits }) => {
+  const [sortedBy, setSortedBy] = useState({
+    ascendingOrder: false,
+    field: ''
+  });
+  const sortCircuitsBy = (sortBy, order) => {
+    setSortedBy({ ascendingOrder: order, field: sortBy });
+    dispatch({
+      type: 'sort',
+      sort: { sortBy, ascendingOrder: order }
+    });
+  };
+
+  useEffect(() => {
+    sortCircuitsBy(sortedBy.field, sortedBy.ascendingOrder);
+  }, [circuits]);
+
+  const caretDown = (
+    <span className="caret">
+      <FontAwesomeIcon icon="caret-down" />
+    </span>
+  );
+
+  const caretUp = (
+    <span className="caret">
+      <FontAwesomeIcon icon="caret-up" />
+    </span>
+  );
+
+  const sortableSymbol = (
+    <span className="caret">
+      <FontAwesomeIcon icon="sort" />
+    </span>
+  );
+  const sortSymbol = fieldType => {
+    if (sortedBy.field !== fieldType) {
+      return sortableSymbol;
+    }
+    if (sortedBy.ascendingOrder) {
+      return caretUp;
+    }
+    return caretDown;
+  };
+  return (
+    <tr className="table-header">
+      <th onClick={() => sortCircuitsBy('comments', !sortedBy.ascendingOrder)}>
+        Comments
+        {sortSymbol('comments')}
+      </th>
+      <th onClick={() => sortCircuitsBy('circuitID', !sortedBy.ascendingOrder)}>
+        Circuit ID
+        {sortSymbol('circuitID')}
+      </th>
+      <th
+        onClick={() => sortCircuitsBy('serviceCount', !sortedBy.ascendingOrder)}
+      >
+        Service count
+        {sortSymbol('serviceCount')}
+      </th>
+      <th
+        onClick={() => {
+          sortCircuitsBy('managementType', !sortedBy.ascendingOrder);
+        }}
+      >
+        Management Type
+        {sortSymbol('managementType')}
+      </th>
+    </tr>
+  );
+};
+
+TableHeader.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  circuits: PropTypes.arrayOf(Circuit).isRequired
+};
+
+export default TableHeader;

--- a/saplings/circuits/src/components/circuitsTable/TableRow.js
+++ b/saplings/circuits/src/components/circuitsTable/TableRow.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { useLocalNodeState } from '../../state/localNode';
+import { Circuit } from '../../data/processCircuits';
+
+const proposalStatus = (circuit, nodeID) => {
+  const exclamation = (
+    <span className="status-icon">
+      <FontAwesomeIcon icon="exclamation" />
+    </span>
+  );
+  const awaiting = (
+    <span className="status awaiting-approval">Awaiting approval</span>
+  );
+  return (
+    <div className="proposal-status">
+      {circuit.actionRequired(nodeID) ? (
+        <span className="status action-required">
+          Action required
+          {exclamation}
+        </span>
+      ) : (
+        ''
+      )}
+      {awaiting}
+    </div>
+  );
+};
+
+const TableRow = ({ circuit }) => {
+  const nodeID = useLocalNodeState();
+  return (
+    <tr className="table-row">
+      <td className="text-highlight">{circuit.id}</td>
+      <td>
+        {
+          new Set(
+            circuit.roster.map(service => {
+              return service.service_type;
+            })
+          ).size
+        }
+      </td>
+      <td>{circuit.managementType}</td>
+      <td className={circuit.comments === 'N/A' ? 'text-grey' : ''}>
+        <div className="circuit-comment">{circuit.comments}</div>
+      </td>
+      <td>
+        {circuit.awaitingApproval() ? proposalStatus(circuit, nodeID) : ''}
+      </td>
+    </tr>
+  );
+};
+
+TableRow.propTypes = {
+  circuit: PropTypes.instanceOf(Circuit).isRequired
+};
+
+export default TableRow;

--- a/saplings/circuits/src/state/circuits.js
+++ b/saplings/circuits/src/state/circuits.js
@@ -55,13 +55,76 @@ const filterCircuits = (circuits, filterBy) => {
   return filteredCircuits;
 };
 
+const sortCircuits = (circuits, action) => {
+  const order = action.ascendingOrder ? -1 : 1;
+  switch (action.sortBy) {
+    case 'comments': {
+      const sorted = circuits.sort((circuitA, circuitB) => {
+        if (circuitA.comments === 'N/A' && circuitB.comments !== 'N/A') {
+          return 1; // 'N/A should always be at the bottom'
+        }
+        if (circuitA.comments !== 'N/A' && circuitB.comments === 'N/A') {
+          return -1; // 'N/A should always be at the bottom'
+        }
+        if (circuitA.comments < circuitB.comments) {
+          return order;
+        }
+        if (circuitA.comments > circuitB.comments) {
+          return -order;
+        }
+        return 0;
+      });
+
+      return sorted;
+    }
+    case 'circuitID': {
+      const sorted = circuits.sort((circuitA, circuitB) => {
+        if (circuitA.id < circuitB.id) {
+          return order;
+        }
+        if (circuitA.id > circuitB.id) {
+          return -order;
+        }
+        return 0;
+      });
+
+      return sorted;
+    }
+    case 'serviceCount': {
+      const sorted = circuits.sort((circuitA, circuitB) => {
+        if (circuitA.roster.length < circuitB.roster.length) {
+          return order;
+        }
+        if (circuitA.roster.length > circuitB.roster.length) {
+          return -order;
+        }
+        return 0;
+      });
+
+      return sorted;
+    }
+    case 'managementType': {
+      const sorted = circuits.sort((circuitA, circuitB) => {
+        if (circuitA.managementType < circuitB.managementType) {
+          return order;
+        }
+        if (circuitA.managementType > circuitB.managementType) {
+          return -order;
+        }
+        return 0;
+      });
+
+      return sorted;
+    }
+    default:
+      return circuits;
+  }
+};
+
 const circuitsReducer = (state, action) => {
   switch (action.type) {
     case 'sort': {
-      const sortedCircuits = action.sortCircuits(
-        state.filteredCircuits,
-        action.sort
-      );
+      const sortedCircuits = sortCircuits(state.filteredCircuits, action.sort);
       return { ...state, filteredCircuits: sortedCircuits };
     }
     case 'filter': {

--- a/saplings/circuits/src/state/circuits.js
+++ b/saplings/circuits/src/state/circuits.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useReducer } from 'react';
+import mockCircuits from '../mockData/mockCircuits';
+import mockProposals from '../mockData/mockProposals';
+import { processCircuits } from '../data/processCircuits';
+
+const filterCircuits = (circuits, filterBy) => {
+  if (filterBy.filterTerm.length === 0) {
+    return circuits;
+  }
+  const filteredCircuits = circuits.filter(circuit => {
+    if (circuit.id.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
+      return true;
+    }
+    if (
+      circuit.managementType.toLowerCase().indexOf(filterBy.filterTerm) > -1
+    ) {
+      return true;
+    }
+    if (circuit.comments.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
+      return true;
+    }
+    if (
+      circuit.members.filter(
+        member => member.toLowerCase().indexOf(filterBy.filterTerm) > -1
+      ).length > 0
+    ) {
+      return true;
+    }
+    if (
+      circuit.roster.filter(
+        service => service.service_type.indexOf(filterBy.filterTerm) > -1
+      ).length > 0
+    ) {
+      return true;
+    }
+    return false;
+  });
+
+  return filteredCircuits;
+};
+
+const circuitsReducer = (state, action) => {
+  switch (action.type) {
+    case 'sort': {
+      const sortedCircuits = action.sortCircuits(
+        state.filteredCircuits,
+        action.sort
+      );
+      return { ...state, filteredCircuits: sortedCircuits };
+    }
+    case 'filter': {
+      const filteredCircuits = filterCircuits(state.circuits, action.filter);
+      return { ...state, filteredCircuits };
+    }
+    default:
+      throw new Error(`unhandled action type: ${action.type}`);
+  }
+};
+
+function useCircuitsState() {
+  const circuits = processCircuits(mockCircuits.concat(mockProposals));
+
+  const [circuitState, circuitsDispatch] = useReducer(circuitsReducer, {
+    circuits,
+    filteredCircuits: circuits
+  });
+  return [circuitState, circuitsDispatch];
+}
+
+export { useCircuitsState };


### PR DESCRIPTION
This adds the circuits table to the main page of the circuit sapling

#### To test
1. Run:
```
docker-compose -f docker/docker-compose up --build
```
2. To see the alpha node UI go to: `localhost:3030`

3. Click on the `circuits` option in the left side menu, it will forward you to  `localhost:3030/circuits`: 
<img width="1192" alt="Screen Shot 2020-04-20 at 8 55 25 AM" src="https://user-images.githubusercontent.com/14094978/79759749-b2ac1d80-82e4-11ea-9c61-78020ebe3dc1.png">

4. Click the table columns and check that they sort the row as expected. Below is the example of sorting the table by comments in ascendant order 
<img width="1192" alt="Screen Shot 2020-04-20 at 8 56 22 AM" src="https://user-images.githubusercontent.com/14094978/79759858-d3747300-82e4-11ea-9e12-ea9a07524a4d.png">


5. Check on the `status` column header and check that you can filter the circuits by status. Below is the result of filtering by "Action required"
<img width="1192" alt="Screen Shot 2020-04-20 at 8 58 00 AM" src="https://user-images.githubusercontent.com/14094978/79760016-0dde1000-82e5-11ea-875e-9f17db2af5e6.png">
<img width="1192" alt="Screen Shot 2020-04-20 at 8 58 20 AM" src="https://user-images.githubusercontent.com/14094978/79760053-1afaff00-82e5-11ea-9613-b6ccc153d8e1.png">


6.  Check that filtering by search term and status show the circuits in intersection of the two filters. Below is the result of filtering by status "action required" and the search term "gameroom":
<img width="1192" alt="Screen Shot 2020-04-20 at 9 01 32 AM" src="https://user-images.githubusercontent.com/14094978/79760342-8cd34880-82e5-11ea-8a82-8db3ea11806b.png">

7. Perform any other tests you can think of, let me know of any bugs or edge cases! 

 
