### PR TITLE
Check for user before rendering circuit sapling

### DIFF
--- a/saplings/circuits/package.json
+++ b/saplings/circuits/package.json
@@ -35,6 +35,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "history": "^4.10.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/saplings/circuits/src/index.js
+++ b/saplings/circuits/src/index.js
@@ -16,11 +16,18 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { registerApp } from 'splinter-saplingjs';
+import { registerApp, getUser } from 'splinter-saplingjs';
+import { createBrowserHistory } from 'history';
 
 import './index.css';
 import App from './App';
 
+const history = createBrowserHistory();
+
 registerApp(domNode => {
-  ReactDOM.render(<App />, domNode);
+  if (getUser()) {
+    ReactDOM.render(<App />, domNode);
+  } else {
+    history.push('/login');
+  }
 });


### PR DESCRIPTION
The circuit sapling will now check if the user is logged in before
rendering. If the user is not logged in, it will redirect them to
the login page.

This fixes an issue where if the user navigates to the circuits page
directly they would occasionally be taken to the page without being
asked to log in and the page would not render the Canopy navbar. This
was caused by a race condition where both the login page and the
circuits page would render simultaneously, causing the page that
finished rendering last to overwrite the first one. This was not an
issue if the login paged rendered last. However, if the circuits page
rendered last the page would render incorrectly. This commit
fixes that issue by forcing the circuits page to redirect the user
in the case that it is the page that finishes rendering last.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>