### PR TITLE
Update redirects in login sapling

### DIFF
--- a/saplings/register-login/src/index.ts
+++ b/saplings/register-login/src/index.ts
@@ -34,6 +34,16 @@ interface FormEventHandler {
   (this: HTMLFormElement, event: Event): void;
 }
 
+interface Canopy {
+  redirectedFrom: string;
+}
+
+declare global {
+  interface Window {
+    $CANOPY: Canopy;
+  }
+}
+
 registerConfigSapling('login', () => {
   let shouldRender = false;
   const canopyURL = new URL(window.location.href);
@@ -145,7 +155,9 @@ registerConfigSapling('login', () => {
               userId: response.data.user_id,
               displayName: user.displayName
             });
-            window.location.href = canopyURL.href;
+            const redirectedFrom = window.$CANOPY.redirectedFrom || '/';
+            window.$CANOPY.redirectedFrom = undefined;
+            window.location.href = redirectedFrom;
           } catch (err) {
             switch (err.response.status) {
               case 400:

--- a/saplings/register-login/src/index.ts
+++ b/saplings/register-login/src/index.ts
@@ -19,8 +19,7 @@ import {
   getUser,
   registerApp,
   setUser,
-  getSharedConfig,
-  hideCanopy
+  getSharedConfig
 } from 'splinter-saplingjs';
 import { createBrowserHistory } from 'history';
 import axios from 'axios';
@@ -58,8 +57,6 @@ registerConfigSapling('login', () => {
   }
 
   if (shouldRender) {
-    hideCanopy();
-
     registerApp(domNode => {
       const div = domNode as HTMLDivElement;
       div.innerHTML = html;


### PR DESCRIPTION
Update how the login sapling redirects a user to the page they were
attempting to navigate to. This is to make it compatible with updates
being made to Canopyjs which will now redirect users to the login page
if they're not logged in. Canopyjs redirects will cause the history to
contain the page the user requested so login simply needs to return that
user to that page after they have been logged in.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>