### PR TITLE
Add services to circuit proposal

### DIFF
--- a/app/src/theme/colors.scss
+++ b/app/src/theme/colors.scss
@@ -31,6 +31,7 @@ $color-secondary-dark: darken($color-secondary, 15%);
   --color-dark-grey: #333333;
   --color-grey: #555555;
   --color-light-grey: #DDDDDD;
+  --color-lighter-grey: #F3F3F3;
   --color-attention: #d94f4f;
   --color-text-on-dark: rgba(255, 255, 255, 0.9);
   --color-text-light-on-dark: rgba(255, 255, 255, 0.7);

--- a/saplings/circuits/src/App.js
+++ b/saplings/circuits/src/App.js
@@ -28,7 +28,10 @@ import {
   faCheck,
   faTimes,
   faPlusCircle,
-  faMinusCircle
+  faMinusCircle,
+  faPen,
+  faTrash,
+  faSyncAlt
 } from '@fortawesome/free-solid-svg-icons';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -51,7 +54,10 @@ library.add(
   faCheck,
   faTimes,
   faPlusCircle,
-  faMinusCircle
+  faMinusCircle,
+  faPen,
+  faTrash,
+  faSyncAlt
 );
 
 function App() {

--- a/saplings/circuits/src/components/PlusMinusButton.js
+++ b/saplings/circuits/src/components/PlusMinusButton.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import './PlusMinusButton.scss';
+
+export const PlusButton = ({ actionFn, display }) => {
+  if (!display) {
+    return '';
+  }
+
+  const plusSign = (
+    <span className="sign plus">
+      <FontAwesomeIcon icon="plus-circle" />
+    </span>
+  );
+
+  return (
+    <button type="button" className="plus-button" onClick={actionFn}>
+      {plusSign}
+    </button>
+  );
+};
+
+PlusButton.propTypes = {
+  actionFn: PropTypes.func.isRequired,
+  display: PropTypes.bool
+};
+
+PlusButton.defaultProps = {
+  display: false
+};
+
+export const MinusButton = ({ actionFn, display }) => {
+  if (!display) {
+    return '';
+  }
+  const minusSign = (
+    <span className="sign minus">
+      <FontAwesomeIcon icon="minus-circle" />
+    </span>
+  );
+
+  return (
+    <button className="minus-button" type="button" onClick={actionFn}>
+      {minusSign}
+    </button>
+  );
+};
+
+MinusButton.propTypes = {
+  actionFn: PropTypes.func.isRequired,
+  display: PropTypes.bool
+};
+
+MinusButton.defaultProps = {
+  display: false
+};

--- a/saplings/circuits/src/components/PlusMinusButton.scss
+++ b/saplings/circuits/src/components/PlusMinusButton.scss
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.minus-button, .plus-button {
+  padding: 0;
+  border: none;
+  outline: none;
+  height: fit-content;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  background-color: transparent;
+}
+
+.plus-button {
+  color: var(--color-primary-light);
+}
+
+.minus-button {
+  color: var(--color-attention);
+}

--- a/saplings/circuits/src/components/ServiceCard.js
+++ b/saplings/circuits/src/components/ServiceCard.js
@@ -1,0 +1,587 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useReducer, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Service } from '../data/circuits';
+import { Node } from '../data/nodeRegistry';
+import { PlusButton, MinusButton } from './PlusMinusButton';
+
+import './ServiceCard.scss';
+
+const isValidID = serviceID => {
+  if (serviceID.length === 4) {
+    const regex = /^[a-zA-Z0-9]+$/i;
+    if (serviceID.match(regex)) {
+      return true;
+    }
+    return false;
+  }
+  return false;
+};
+
+const generateServiceID = () => {
+  const idLenght = 4;
+  let id = '';
+  for (let i = 0; i < idLenght; i += 1) {
+    const capitalize = Math.random() >= 0.5;
+    let idChar = Math.random()
+      .toString(36)
+      .substring(2, 3);
+    if (capitalize) {
+      idChar = idChar.toUpperCase();
+    }
+    id += idChar;
+  }
+
+  return id;
+};
+
+const serviceReducer = (state, action) => {
+  switch (action.type) {
+    case 'set-service-type': {
+      const { serviceType } = action;
+      const { errors, service } = state;
+      if (serviceType.length === 0) {
+        errors.serviceType = 'Service type cannot be empty';
+      } else {
+        errors.serviceType = '';
+      }
+      service.serviceType = serviceType;
+
+      return { ...state, service, errors };
+    }
+    case 'set-service-id': {
+      const { serviceID } = action;
+      const { errors, service } = state;
+      if (serviceID.length === 0) {
+        errors.serviceID = 'Service ID cannot be empty';
+      } else if (!isValidID(serviceID)) {
+        errors.serviceID =
+          'Invalid service ID. It must be 4 characters long and contain only ASCII alphanumeric characters.';
+      } else {
+        errors.serviceID = '';
+      }
+      service.serviceID = serviceID;
+
+      return { ...state, serviceID, errors };
+    }
+    case 'set-allowed-nodes': {
+      const { allowedNodes } = action;
+      const { errors, service } = state;
+      if (allowedNodes.length === 0) {
+        errors.allowedNodes = 'Allowed nodes cannot be empty';
+      } else {
+        errors.allowedNodes = '';
+      }
+
+      service.allowedNodes = allowedNodes;
+
+      return { ...state, service, errors };
+    }
+    case 'check-allowed-nodes': {
+      const { errors } = state;
+      if (state.service.allowedNodes.length === 0) {
+        errors.allowedNodes = 'Allowed nodes cannot be empty';
+      } else {
+        errors.allowedNodes = '';
+      }
+
+      return { ...state, errors };
+    }
+    case 'set-arguments': {
+      const args = action.arguments;
+      const { errors, service } = state;
+      if (args.length === 0) {
+        errors.arguments = 'Service arguments cannot be empty';
+      } else {
+        errors.arguments = '';
+      }
+
+      service.arguments = args;
+
+      return { ...state, service, errors };
+    }
+    case 'set-service': {
+      const { service } = action;
+      return { ...state, service };
+    }
+    default:
+      throw new Error(`unhandled action type: ${action.type}`);
+  }
+};
+
+const argumentsReducer = (state, action) => {
+  switch (action.type) {
+    case 'add-field': {
+      state.arguments.push({
+        key: '',
+        value: ''
+      });
+      return { ...state };
+    }
+    case 'remove-field': {
+      const { index } = action;
+      state.arguments.splice(index, 1);
+      return { ...state };
+    }
+    case 'set-field-key': {
+      const newState = state;
+      const { key, index } = action;
+      newState.arguments[index].key = key;
+      if (key.length !== 0) {
+        delete newState.errors[index];
+      }
+
+      if (key.length === 0 && newState.arguments[index].value.length !== 0) {
+        const error = 'Key cannot be empty';
+        newState.errors[index] = error;
+      }
+
+      return { ...newState };
+    }
+    case 'set-field-value': {
+      const newState = state;
+      const { value, index } = action;
+      newState.arguments[index].value = value;
+      if (newState.arguments[index].key.length === 0 && value.length !== 0) {
+        const error = 'Key cannot be empty';
+        newState.errors[index] = error;
+      } else {
+        delete newState.errors[index];
+      }
+      return { ...newState };
+    }
+    case 'reset-arguments': {
+      const args = Object.entries(action.arguments).map(([key, value]) => {
+        return {
+          key,
+          value
+        };
+      });
+      return { ...state, arguments: args };
+    }
+    case 'filter-empty': {
+      const filteredArgs = state.arguments.filter(arg => {
+        if (arg.key.length > 0) {
+          return true;
+        }
+        return false;
+      });
+
+      return { ...state, arguments: filteredArgs };
+    }
+    case 'clear': {
+      return {
+        arguments: [
+          {
+            key: '',
+            value: ''
+          }
+        ],
+        errors: {}
+      };
+    }
+    default:
+      throw new Error(`unhandled action type: ${action.type}`);
+  }
+};
+
+const ServiceCard = ({
+  service,
+  applyServiceChanges,
+  deleteService,
+  isEditable,
+  enterEditMode,
+  isDeletable,
+  nodes,
+  localNodeID
+}) => {
+  const [editMode, setEditMode] = useState(enterEditMode);
+  const [deleteOnDismiss, setDeleteOnDismiss] = useState(true);
+  const [formComplete, setFormComplete] = useState(false);
+  const [serviceState, serviceDispatcher] = useReducer(serviceReducer, {
+    service: { ...service },
+    errors: {
+      serviceType: '',
+      serviceID: '',
+      allowedNodes: '',
+      serviceArguments: ''
+    }
+  });
+  const [showAllowedNodes, setShowAllowedNodes] = useState(false);
+  const [argumentsState, argumentsDispatcher] = useReducer(argumentsReducer, {
+    arguments: Object.entries(serviceState.service.arguments).map(
+      ([key, value]) => {
+        return {
+          key,
+          value
+        };
+      }
+    ),
+    errors: {}
+  });
+
+  useEffect(() => {
+    serviceDispatcher({ type: 'set-service', service: { ...service } });
+  }, [service]);
+
+  useEffect(() => {
+    const serviceTypeIsValid =
+      serviceState.errors.serviceType.length === 0 &&
+      serviceState.service.serviceType.length !== 0;
+
+    const serviceIDIsValid =
+      serviceState.errors.serviceID.length === 0 &&
+      serviceState.service.serviceID.length !== 0;
+
+    const allowedNodesIsValid =
+      serviceState.errors.allowedNodes.length === 0 &&
+      serviceState.service.allowedNodes.length !== 0;
+
+    const serviceArgumentsIsValid =
+      Object.keys(argumentsState.errors).length === 0;
+
+    if (
+      serviceTypeIsValid &&
+      serviceIDIsValid &&
+      allowedNodesIsValid &&
+      serviceArgumentsIsValid
+    ) {
+      setFormComplete(true);
+    } else {
+      setFormComplete(false);
+    }
+  }, [serviceState, argumentsState]);
+
+  const caretDown = (
+    <span className="icon-btn caret">
+      <FontAwesomeIcon icon="caret-down" />
+    </span>
+  );
+
+  const caretUp = (
+    <span className="icon-btn caret">
+      <FontAwesomeIcon icon="caret-up" />
+    </span>
+  );
+
+  const editButton = (
+    <button
+      className="icon-btn"
+      type="button"
+      title="Edit service"
+      onClick={() => {
+        setEditMode(true);
+        setDeleteOnDismiss(false);
+      }}
+    >
+      <FontAwesomeIcon icon="pen" />
+    </button>
+  );
+
+  const deleteButton = (
+    <button
+      className="icon-btn"
+      title="Delete service"
+      type="button"
+      disabled={!isDeletable}
+      onClick={() => {
+        deleteService();
+      }}
+    >
+      <FontAwesomeIcon icon="trash" />
+    </button>
+  );
+
+  const confirmButton = (
+    <button
+      className="icon-btn color-confirm"
+      type="button"
+      onClick={async () => {
+        setEditMode(false);
+        const args = {};
+        argumentsState.arguments.forEach(arg => {
+          if (arg.key.length > 0) {
+            args[arg.key] = arg.value;
+          }
+        });
+        serviceDispatcher({ type: 'set-arguments', arguments: args });
+        argumentsDispatcher({ type: 'filter-empty' });
+        applyServiceChanges({ ...serviceState.service, arguments: args });
+      }}
+      title="Submit changes"
+      disabled={!formComplete}
+    >
+      <FontAwesomeIcon icon="check" />
+    </button>
+  );
+
+  const dismissButton = (
+    <button
+      className="icon-btn color-danger"
+      type="button"
+      title="Dismiss changes"
+      disabled={!isDeletable && deleteOnDismiss}
+      onClick={() => {
+        if (deleteOnDismiss) {
+          deleteService();
+        } else {
+          serviceDispatcher({ type: 'set-service', service: { ...service } });
+          argumentsDispatcher({
+            type: 'reset-arguments',
+            arguments: { ...service.arguments }
+          });
+          setEditMode(false);
+        }
+      }}
+    >
+      <FontAwesomeIcon icon="times" />
+    </button>
+  );
+
+  const allowedNodes = (
+    <input
+      className="service-input"
+      value={serviceState.service.allowedNodes}
+      disabled
+    />
+  );
+
+  const allowedNodeEditMode = (
+    <div>
+      <button
+        type="button"
+        className="allowed-nodes-dropdown service-input"
+        onClick={() => {
+          if (showAllowedNodes) {
+            serviceDispatcher({ type: 'check-allowed-nodes' });
+          }
+          setShowAllowedNodes(!showAllowedNodes);
+        }}
+      >
+        {serviceState.service.allowedNodes}
+        {showAllowedNodes ? caretUp : caretDown}
+      </button>
+      <ul
+        className={
+          showAllowedNodes ? 'allowed-nodes-list show' : 'allowed-nodes-list'
+        }
+      >
+        {nodes.map(node => {
+          const selected =
+            node.identity === serviceState.service.allowedNodes[0];
+          return (
+            <button
+              type="button"
+              className="allowed-nodes-item service-input"
+              onClick={() => {
+                setShowAllowedNodes(false);
+                serviceDispatcher({
+                  type: 'set-allowed-nodes',
+                  allowedNodes: [node.identity]
+                });
+              }}
+            >
+              <div className="field-wrapper">
+                <div className="field-header">Name</div>
+                <div className="field-value">{node.displayName}</div>
+              </div>
+              <div className="field-wrapper">
+                <div className="field-header">ID</div>
+                <div className="field-value">{node.identity}</div>
+                {localNodeID === node.identity && (
+                  <div className="field-value">(Local)</div>
+                )}
+              </div>
+              <FontAwesomeIcon
+                icon="check"
+                className={selected ? 'check-mark' : 'check-mark not-visible'}
+              />
+            </button>
+          );
+        })}
+      </ul>
+    </div>
+  );
+
+  const serviceArguments = () => {
+    if (argumentsState.arguments.length === 0 && editMode) {
+      argumentsDispatcher({ type: 'add-field' });
+    }
+
+    return argumentsState.arguments.map((arg, i) => {
+      return (
+        <div className="arguments-input-wrapper flex-input">
+          <input
+            className="service-input arguments-input"
+            value={arg.key}
+            placeholder="Key"
+            disabled={!editMode}
+            onChange={e => {
+              const input = e.target.value;
+              argumentsDispatcher({
+                type: 'set-field-key',
+                key: input,
+                index: i
+              });
+            }}
+          />
+          <input
+            className="service-input arguments-input"
+            value={arg.value}
+            placeholder="Value"
+            disabled={!editMode}
+            onChange={e => {
+              const input = e.target.value;
+              argumentsDispatcher({
+                type: 'set-field-value',
+                value: input,
+                index: i
+              });
+            }}
+          />
+          {editMode && (
+            <PlusButton
+              actionFn={() => {
+                argumentsDispatcher({
+                  type: 'add-field'
+                });
+              }}
+              display
+            />
+          )}
+          {editMode && (
+            <MinusButton
+              actionFn={() => {
+                argumentsDispatcher({
+                  type: 'remove-field',
+                  index: i
+                });
+              }}
+              display={argumentsState.arguments.length > 1}
+            />
+          )}
+          <div className="form-error">{argumentsState.errors[i]}</div>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <div className="service-card">
+      <div className="service-header bg-color-grey">
+        {isEditable && !editMode && editButton}
+        {isEditable && !editMode && deleteButton}
+        {isEditable && editMode && confirmButton}
+        {isEditable && editMode && dismissButton}
+      </div>
+      <div className="service-fields">
+        <div className="service-field">
+          <div className="field-name">Service type</div>
+          <div className="field-input">
+            <input
+              className="service-input"
+              value={serviceState.service.serviceType}
+              onChange={e => {
+                serviceDispatcher({
+                  type: 'set-service-type',
+                  serviceType: e.target.value
+                });
+              }}
+              disabled={!editMode}
+            />
+            <div className="form-error">{serviceState.errors.serviceType}</div>
+          </div>
+        </div>
+        <div className="service-field bg-color-grey">
+          <div className="field-name">Service ID</div>
+          <div className="field-input">
+            <div className="flex-input">
+              <input
+                className="service-input service-id-input"
+                value={serviceState.service.serviceID}
+                onChange={e => {
+                  serviceDispatcher({
+                    type: 'set-service-id',
+                    serviceID: e.target.value
+                  });
+                }}
+                maxLength="4"
+                disabled={!editMode}
+              />
+              {editMode && (
+                <button
+                  className="icon-btn"
+                  type="button"
+                  onClick={() => {
+                    const id = generateServiceID();
+                    serviceDispatcher({
+                      type: 'set-service-id',
+                      serviceID: id
+                    });
+                  }}
+                  title="Generate service ID"
+                >
+                  <FontAwesomeIcon icon="sync-alt" />
+                </button>
+              )}
+            </div>
+            <div className="form-error">{serviceState.errors.serviceID}</div>
+          </div>
+        </div>
+        <div className="service-field">
+          <div className="field-name">Allowed node</div>
+          <div className="field-input">
+            {!editMode && allowedNodes}
+            {editMode && allowedNodeEditMode}
+            <div className="form-error">{serviceState.errors.allowedNodes}</div>
+          </div>
+        </div>
+        <div className="service-field bg-color-grey">
+          <div className="field-name">Service arguments</div>
+          <div className="field-input service-arguments">
+            {serviceArguments()}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ServiceCard.propTypes = {
+  service: PropTypes.instanceOf(Service).isRequired,
+  applyServiceChanges: PropTypes.func,
+  deleteService: PropTypes.func,
+  enterEditMode: PropTypes.bool,
+  isEditable: PropTypes.bool,
+  isDeletable: PropTypes.bool,
+  nodes: PropTypes.arrayOf(Node),
+  localNodeID: PropTypes.string
+};
+
+ServiceCard.defaultProps = {
+  applyServiceChanges: undefined,
+  deleteService: undefined,
+  enterEditMode: false,
+  isEditable: false,
+  isDeletable: true,
+  nodes: [],
+  localNodeID: ''
+};
+
+export default ServiceCard;

--- a/saplings/circuits/src/components/ServiceCard.scss
+++ b/saplings/circuits/src/components/ServiceCard.scss
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ .service-card {
+   display: flex;
+   flex-direction: column;
+   border: 1px solid var(--color-light-grey);
+   border-radius: 0.3rem;
+   width: 100%;
+   height: 60%;
+   margin-bottom: 0.5rem;
+   position: relative;
+
+   .not-visible {
+     visibility: hidden;
+   }
+
+   .form-error {
+     font-size: 0.7rem;
+     color: var(--color-attention);
+     margin-top: 0.3rem;
+   }
+
+   .icon-btn {
+     border: none;
+     outline: none;
+     font-size: 0.8rem;
+     color: var(--color-grey);
+     padding: 0;
+     margin-left: 0.8rem;
+     height: fit-content;
+     cursor: pointer;
+
+     &.color-danger {
+       color: var(--color-attention);
+     }
+
+     &.color-confirm {
+       color: #2CB5A5;
+     }
+
+     &:disabled {
+       color: var(--color-light-grey);
+     }
+   }
+
+   .bg-color-grey {
+     background-color: var(--color-lighter-grey);
+   }
+
+   .service-header {
+     display: flex;
+     flex-direction: row;
+     justify-content: flex-end;
+     padding: 0.5rem 0.8rem;
+     height: 15%;
+   }
+
+   .service-fields {
+     width: 100%;
+     font-size: 0.8rem;
+     height: 85%;
+
+     .service-field {
+       width: 100%;
+       display: flex;
+       flex-direction: row;
+       height: 25%;
+
+       .field-name {
+         width: 35%;
+         border-right: 1px solid var(--color-light-grey);
+         padding: 0.6rem 0.8rem;
+       }
+
+       .field-input {
+         width: 65%;
+         padding: 0.6rem 0.8rem;
+         overflow-y: auto;
+
+         .flex-input {
+           display: flex;
+           flex-direction: row;
+         }
+
+         .service-input {
+           background-color: transparent;
+           border: none;
+           outline: none;
+           width: 100%;
+           font-size: inherit;
+           border-bottom: 1px solid var(--color-light-grey);
+
+           &:disabled {
+             border-bottom: none;
+           }
+
+           &.arguments-input {
+             width: 40%;
+             margin-right: 0.3rem;
+           }
+
+           &.service-id-input {
+             width: 90%;
+           }
+
+         }
+         .arguments-input-wrapper {
+           .minus-button, .plus-button {
+             visibility: hidden;
+           }
+           &:hover {
+             .minus-button, .plus-button {
+                visibility: visible;
+             }
+           }
+         }
+       }
+     }
+
+     .allowed-nodes-dropdown {
+        letter-spacing: normal;
+        text-align: left;
+        color: var(--color-grey);
+        padding: 0;
+        position: relative;
+        display: inline-block;
+
+        .caret {
+          float: right;
+        }
+      }
+
+      .allowed-nodes-list {
+        position: absolute;
+        z-index: 1;
+        background-color: var(--background-color-white);
+        box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+        max-height: 30%;
+        overflow-y: auto;
+        padding: 0;
+        margin-top: 0;
+        display: none;
+
+        &.show {
+          display: block;
+        }
+
+        .allowed-nodes-item {
+          display: grid;
+          grid-template-columns: 1fr 1fr auto;
+          grid-gap: 0.5rem;
+          padding: 0.3rem 0.5rem;
+          cursor: pointer;
+
+          &:hover {
+            background-color: var(--color-light-grey);
+          }
+
+          .field-wrapper {
+            display: flex;
+            flex-direction: column;
+            text-align: left;
+
+            .field-header {
+              font-size: 0.7rem;
+              margin-bottom: 0.2rem;
+            }
+
+            .field-value {
+              font-size: 0.8rem;
+              font-weight: bold;
+            }
+          }
+
+          .check-mark {
+            align-self: center;
+          }
+        }
+      }
+   }
+ }
+
+ @media only screen and (max-width: 600px) {
+  .service-card {
+    .service-fields {
+      .service-field {
+        .field-input {
+          .arguments-input-wrapper {
+            .minus-button, .plus-button {
+              visibility: visible;
+            }
+          }
+        }
+      }
+    }
+  }
+ }

--- a/saplings/circuits/src/components/forms/MultiStepForm.js
+++ b/saplings/circuits/src/components/forms/MultiStepForm.js
@@ -34,7 +34,8 @@ export function MultiStepForm({
   style,
   disabled,
   error,
-  children
+  children,
+  isStepValidFn
 }) {
   const [step, setStep] = useState(1);
 
@@ -103,8 +104,8 @@ export function MultiStepForm({
           {step < children.length && (
             <button
               type="button"
-              disabled={disabled}
               className="form-button confirm"
+              disabled={!isStepValidFn(step)}
               onClick={next}
             >
               Next
@@ -144,7 +145,8 @@ MultiStepForm.propTypes = {
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   disabled: PropTypes.bool,
   error: PropTypes.bool,
-  children: PropTypes.node
+  children: PropTypes.node,
+  isStepValidFn: PropTypes.func
 };
 
 MultiStepForm.defaultProps = {
@@ -152,5 +154,8 @@ MultiStepForm.defaultProps = {
   style: undefined,
   disabled: false,
   error: false,
-  children: undefined
+  children: undefined,
+  isStepValidFn: () => {
+    return true;
+  }
 };

--- a/saplings/circuits/src/components/forms/MultiStepForm.js
+++ b/saplings/circuits/src/components/forms/MultiStepForm.js
@@ -96,15 +96,15 @@ export function MultiStepForm({
         </form>
         <div className="actions">
           {step > 1 && (
-            <button type="button" onClick={previous}>
+            <button className="form-button" type="button" onClick={previous}>
               Previous
             </button>
           )}
           {step < children.length && (
             <button
               type="button"
-              className="confirm"
               disabled={disabled}
+              className="form-button confirm"
               onClick={next}
             >
               Next
@@ -114,7 +114,7 @@ export function MultiStepForm({
             <button
               type="button"
               onClick={submit}
-              className="submit"
+              className="form-button submit"
               disabled={disabled || error}
             >
               Submit

--- a/saplings/circuits/src/components/forms/MultiStepForm.scss
+++ b/saplings/circuits/src/components/forms/MultiStepForm.scss
@@ -178,7 +178,7 @@
     margin: 1rem 0;
   }
 
-  button {
+  .form-button {
     height: 2.5rem;
     border-radius: 5%;
     width: fit-content;

--- a/saplings/circuits/src/components/forms/NewNodeForm.js
+++ b/saplings/circuits/src/components/forms/NewNodeForm.js
@@ -15,66 +15,13 @@
  */
 
 import React, { useState, useEffect, useReducer } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useToasts } from 'react-toast-notifications';
 import PropTypes from 'prop-types';
 import { postNode } from '../../api/splinter';
 import { Node } from '../../data/nodeRegistry';
+import { PlusButton, MinusButton } from '../PlusMinusButton';
 
 import './NewNodeForm.scss';
-
-const PlusButton = ({ actionFn, display }) => {
-  if (!display) {
-    return '';
-  }
-
-  const plusSign = (
-    <span className="sign plus">
-      <FontAwesomeIcon icon="plus-circle" />
-    </span>
-  );
-
-  return (
-    <button type="button" className="plus-button" onClick={actionFn}>
-      {plusSign}
-    </button>
-  );
-};
-
-PlusButton.propTypes = {
-  actionFn: PropTypes.func.isRequired,
-  display: PropTypes.bool
-};
-
-PlusButton.defaultProps = {
-  display: false
-};
-
-const MinusButton = ({ actionFn, display }) => {
-  if (!display) {
-    return '';
-  }
-  const minusSign = (
-    <span className="sign minus">
-      <FontAwesomeIcon icon="minus-circle" />
-    </span>
-  );
-
-  return (
-    <button className="minus-button" type="button" onClick={actionFn}>
-      {minusSign}
-    </button>
-  );
-};
-
-MinusButton.propTypes = {
-  actionFn: PropTypes.func.isRequired,
-  display: PropTypes.bool
-};
-
-MinusButton.defaultProps = {
-  display: false
-};
 
 const endpointsReducer = (state, action) => {
   switch (action.type) {
@@ -540,7 +487,7 @@ export function NewNodeForm({ closeFn, successCallback }) {
         <div className="form-btn-wrapper">
           <button
             type="button"
-            className="form-btn cancel"
+            className="form-button form-btn cancel"
             onClick={() => {
               clearState();
               closeFn();
@@ -551,7 +498,7 @@ export function NewNodeForm({ closeFn, successCallback }) {
           <button
             type="button"
             disabled={!formComplete}
-            className="form-btn submit"
+            className="form-button form-btn submit"
             onClick={submitNode}
           >
             Submit

--- a/saplings/circuits/src/components/forms/NewNodeForm.scss
+++ b/saplings/circuits/src/components/forms/NewNodeForm.scss
@@ -83,26 +83,13 @@
     .input-wrapper {
       .minus-button {
         visibility: hidden;
-        color: var(--color-attention);
       }
+      
        &:hover {
         .minus-button {
           visibility: visible;
         }
       }
-      .plus-button {
-        color: var(--color-primary-light);
-      }
-    }
-
-    .minus-button, .plus-button {
-      padding: 0;
-      border: 0;
-      outline: none;
-      height: fit-content;
-      cursor: pointer;
-      margin-left: 0.5rem;
-      background-color: transparent;
     }
 
     input {

--- a/saplings/circuits/src/components/forms/ProposeCircuitForm.js
+++ b/saplings/circuits/src/components/forms/ProposeCircuitForm.js
@@ -214,11 +214,20 @@ export function ProposeCircuitForm() {
     }
   }, [localNode]);
 
+  const stepValidationFn = stemNumber => {
+    switch (stemNumber) {
+      case 1:
+        return nodesAreValid();
+      default:
+        return true;
+    }
+  };
+
   return (
     <MultiStepForm
       formName="Propose Circuit"
       handleSubmit={() => {}}
-      disabled={!nodesAreValid()}
+      isStepValidFn={stepNumber => stepValidationFn(stepNumber)}
     >
       <Step step={1} label="Add nodes">
         <div className="step-header">

--- a/saplings/circuits/src/components/forms/ProposeCircuitForm.js
+++ b/saplings/circuits/src/components/forms/ProposeCircuitForm.js
@@ -307,7 +307,7 @@ export function ProposeCircuitForm() {
                 );
               })}
               <button
-                className="new-node-button"
+                className="form-button new-node-button"
                 type="button"
                 onClick={() => {
                   setModalActive(true);

--- a/saplings/circuits/src/components/forms/ProposeCircuitForm.scss
+++ b/saplings/circuits/src/components/forms/ProposeCircuitForm.scss
@@ -188,6 +188,29 @@
   }
 }
 
+.services-wrapper {
+  margin-top: 1rem;
+  height: 85%;
+  overflow-y: auto;
+}
+
+.add-service-btn-wrapper {
+  height: 5%;
+  text-align: center;
+  padding-top: 0.5rem;
+
+  .add-service-button {
+    width: 2rem;
+    height: 2rem;
+    color: var(--color-primary);
+    border-radius: 2rem;
+    background-color: transparent;
+    text-align: center;
+    border: 1px solid var(--color-primary);
+    outline: none;
+  }
+}
+
 @media only screen and (max-width: 600px) {
   .node-registry-wrapper {
     .available-nodes {

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -16,6 +16,20 @@
 
 import Paging from './paging';
 
+function Service(data) {
+  if (data) {
+    this.serviceID = data.service_id;
+    this.serviceType = data.serviceType;
+    this.allowedNodes = data.allowed_nodes;
+    this.arguments = data.arguments;
+  } else {
+    this.serviceID = '';
+    this.serviceType = '';
+    this.allowedNodes = [];
+    this.arguments = {};
+  }
+}
+
 function Circuit(data) {
   if (data.proposal_type) {
     this.id = data.circuit_id;
@@ -23,7 +37,9 @@ function Circuit(data) {
     this.members = data.circuit.members.map(member => {
       return member.node_id;
     });
-    this.roster = data.circuit.roster;
+    this.roster = data.circuit.roster.map(service => {
+      return new Service(service);
+    });
     this.managementType = data.circuit.management_type;
     this.applicationMetadata = data.circuit.application_metadata;
     this.comments = data.circuit.comments;
@@ -79,4 +95,4 @@ function actionRequired(nodeID) {
 Circuit.prototype.awaitingApproval = awaitingApproval;
 Circuit.prototype.actionRequired = actionRequired;
 
-export { Circuit, ListCircuitsResponse };
+export { Circuit, ListCircuitsResponse, Service };


### PR DESCRIPTION
This PR add the partial form to add services to a circuit proposal

### To Test 

1. Run:
```
docker-compose -f docker/docker-compose.yaml up --build
```
2. To see the alpha node UI go to: `localhost:3030`

3. Click on the `circuits` option in the left side menu, it will forward you to  `localhost:3030/circuits`:
<img width="1005" alt="Screen Shot 2020-06-11 at 8 15 48 AM" src="https://user-images.githubusercontent.com/14094978/84389783-333c1b80-abbc-11ea-95c6-a6bbeed42f82.png">

4. Click "Propose Circuit" button. You will be forward to the Propose Circuit Form. Select a node or create a new one if you wish.
<img width="1274" alt="Screen Shot 2020-06-15 at 3 47 27 PM" src="https://user-images.githubusercontent.com/14094978/84704514-9365f100-af1f-11ea-811e-b35ff06622a6.png">

5. Click "Next" to got to the "Add services" session. Enter the services information in the form, play with the controls.  
<img width="1278" alt="Screen Shot 2020-06-17 at 6 26 50 PM" src="https://user-images.githubusercontent.com/14094978/84960776-25106280-b0c8-11ea-9dec-d220b833f7e7.png">
