### PR TITLE
Add form to vote on a proposal 

### DIFF
--- a/saplings/circuits/src/api/payload.js
+++ b/saplings/circuits/src/api/payload.js
@@ -40,6 +40,12 @@ export const makeSignedPayload = (
         protos.CircuitManagementPayload.Action.CIRCUIT_CREATE_REQUEST;
       break;
     }
+    case 'voteCircuitProposal': {
+      actionBytes = protos.CircuitProposalVote.encode(action).finish();
+      payload.circuitProposalVote = action;
+      actionEnum = protos.CircuitManagementPayload.Action.CIRCUIT_PROPOSAL_VOTE;
+      break;
+    }
     default:
       throw new Error(`unhandled action type: ${action.type}`);
   }

--- a/saplings/circuits/src/components/NodeCard.js
+++ b/saplings/circuits/src/components/NodeCard.js
@@ -17,6 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Node } from '../data/nodeRegistry';
 
 import './NodeCard.scss';
 

--- a/saplings/circuits/src/components/OverlayModal.scss
+++ b/saplings/circuits/src/components/OverlayModal.scss
@@ -29,7 +29,7 @@
   .content {
     display: none;
     width: auto;
-    width: 60%;
+    width: 70%;
     height: 80%;
     position: relative;
     top: 10%;

--- a/saplings/circuits/src/components/ProposalReview.js
+++ b/saplings/circuits/src/components/ProposalReview.js
@@ -71,8 +71,13 @@ const ProposalReview = ({
       </div>
       <div class-name="metadata-container">
         <div className="title">Metadata</div>
-        <div className="label">Encoding</div>
-        <div className="field-value">{metadata.encoding}</div>
+        {metadata.encoding && (
+          <div>
+            <div className="label">Encoding</div>
+            <div className="field-value">{metadata.encoding}</div>
+          </div>
+        )}
+
         <div className="label">Value</div>
         <div className="field-value">{metadata.metadata}</div>
       </div>

--- a/saplings/circuits/src/components/ProposalReview.scss
+++ b/saplings/circuits/src/components/ProposalReview.scss
@@ -28,6 +28,7 @@
   .field-value {
     color: var(--color-grey);
     font-size: 0.9rem;
+    word-wrap: break-word;
   }
 
   .content-container {

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
@@ -32,11 +32,17 @@ import { Circuit } from '../../data/circuits';
 import { useCircuitState } from '../../state/circuits';
 import { getNodeRegistry } from '../../api/splinter';
 import ServiceDetails from './ServiceDetails';
+import VoteButton from './VoteButton';
+import { useLocalNodeState } from '../../state/localNode';
+import { OverlayModal } from '../OverlayModal';
+import VoteOnProposalForm from '../forms/VoteOnProposalForm';
 import { Node } from '../../data/nodeRegistry';
 
 const CircuitDetails = () => {
   const { circuitId } = useParams();
   const [circuit] = useCircuitState(circuitId);
+  const localNodeID = useLocalNodeState();
+  const [modalActive, setModalActive] = React.useState(false);
   const [nodes, setNodes] = React.useState(null);
 
   React.useEffect(() => {
@@ -81,14 +87,23 @@ const CircuitDetails = () => {
             </Link>
           </div>
           {requiresAction}
-          <div className="circuit-title">
-            <h4>{`Circuit ${circuitId}`}</h4>
-            <div className="managementType">
-              {circuit.managementType}
-              <span>
-                <FontAwesomeIcon icon={faQuestionCircle} />
-              </span>
+          <div className="mid-header-wrapper">
+            <div className="circuit-title">
+              <h4>{`Circuit ${circuitId}`}</h4>
+              <div className="managementType">
+                {circuit.managementType}
+                <span>
+                  <FontAwesomeIcon icon={faQuestionCircle} />
+                </span>
+              </div>
             </div>
+            {circuit.actionRequired(localNodeID) && (
+              <VoteButton
+                onClickFn={() => {
+                  setModalActive(true);
+                }}
+              />
+            )}
           </div>
         </div>
       </div>
@@ -112,6 +127,15 @@ const CircuitDetails = () => {
 
         <NodesTable circuit={circuit} nodes={nodes} />
       </div>
+      <OverlayModal open={modalActive}>
+        <VoteOnProposalForm
+          proposal={circuit}
+          nodes={nodes}
+          closeFn={() => {
+            setModalActive(false);
+          }}
+        />
+      </OverlayModal>
     </div>
   );
 };

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
@@ -17,6 +17,7 @@
 .circuit-header {
   display: flex;
   flex-direction: column;
+  width: 100%;
 
   .back-button {
     flex: 1;
@@ -42,6 +43,12 @@
     span {
       margin-left: .25rem;
     }
+  }
+
+  .mid-header-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
   }
 
   .circuit-title {

--- a/saplings/circuits/src/components/circuitDetails/VoteButton.js
+++ b/saplings/circuits/src/components/circuitDetails/VoteButton.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './VoteButton.scss';
+
+const VoteButton = ({ onClickFn }) => {
+  const userHasKeys = window.$CANOPY.getKeys();
+
+  return (
+    <button
+      type="button"
+      className="vote-button"
+      disabled={!userHasKeys}
+      onClick={onClickFn}
+    >
+      Vote on proposal
+    </button>
+  );
+};
+
+VoteButton.propTypes = {
+  onClickFn: PropTypes.func.isRequired
+};
+
+export default VoteButton;

--- a/saplings/circuits/src/components/circuitDetails/VoteButton.scss
+++ b/saplings/circuits/src/components/circuitDetails/VoteButton.scss
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+.vote-button {
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  color: var(--color-primary);
+  cursor: pointer;
+  height: 3rem;
+
+  &:disabled {
+    background: var(--color-light-grey);
+    border: none;
+    color: var(--color-text-on-dark);
+    cursor: default;
+  }
+}

--- a/saplings/circuits/src/components/forms/VoteOnProposalForm.js
+++ b/saplings/circuits/src/components/forms/VoteOnProposalForm.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useToasts } from 'react-toast-notifications';
+import { useHistory } from 'react-router-dom';
+
+import ProposalReview from '../ProposalReview';
+import { Circuit } from '../../data/circuits';
+import { Node } from '../../data/nodeRegistry';
+import protos from '../../protobuf';
+import { makeSignedPayload } from '../../api/payload';
+import { postCircuitManagementPayload } from '../../api/splinter';
+import { useLocalNodeState } from '../../state/localNode';
+
+import './VoteOnProposalForm.scss';
+
+const VoteOnProposalForm = ({ proposal, nodes, closeFn }) => {
+  const { addToast } = useToasts();
+  const history = useHistory();
+
+  const localNodeID = useLocalNodeState();
+
+  if (proposal === null || nodes === null) {
+    return <div />;
+  }
+
+  const handleVote = async vote => {
+    let voteEnum = null;
+    let redirect = false;
+    switch (vote) {
+      case 'accept':
+        voteEnum = protos.CircuitProposalVote.Vote.ACCEPT;
+        break;
+      case 'reject':
+        voteEnum = protos.CircuitProposalVote.Vote.REJECT;
+        redirect = true;
+        break;
+      default:
+        throw new Error(`invalid vote: ${vote}`);
+    }
+
+    const votePayload = protos.CircuitProposalVote.create({
+      circuitId: proposal.id,
+      circuitHash: proposal.proposal.circuitHash,
+      vote: voteEnum
+    });
+
+    const { privateKey } = window.$CANOPY.getKeys();
+
+    const payload = makeSignedPayload(
+      localNodeID,
+      privateKey,
+      votePayload,
+      'voteCircuitProposal'
+    );
+
+    try {
+      await postCircuitManagementPayload(payload);
+      addToast('Vote submitted successfully', {
+        appearance: 'success'
+      });
+      closeFn();
+      if (redirect) {
+        history.push(`/circuits`);
+      }
+    } catch (e) {
+      addToast(`${e}`, { appearance: 'error' });
+    }
+  };
+
+  return (
+    <div className="vote-on-proposal-form">
+      <div className="form-header">
+        <div className="form-title">Vote on circuit proposal</div>
+        <div className="help-text">
+          Review the circuit information below and submit your vote.
+        </div>
+      </div>
+      <div className="proposal-review-wrapper">
+        <ProposalReview
+          members={nodes}
+          services={proposal.roster}
+          comments={proposal.comments}
+          metadata={{ metadata: proposal.applicationMetadata }}
+          managementType={proposal.managementType}
+        />
+      </div>
+      <div className="form-footer">
+        <button className="form-button" type="button" onClick={closeFn}>
+          Cancel
+        </button>
+        <div className="vote-buttons">
+          <button
+            className="form-button reject"
+            type="button"
+            onClick={() => {
+              handleVote('reject');
+            }}
+          >
+            Reject
+          </button>
+          <button
+            className="form-button accept"
+            type="button"
+            onClick={() => {
+              handleVote('accept');
+            }}
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+VoteOnProposalForm.propTypes = {
+  proposal: PropTypes.instanceOf(Circuit).isRequired,
+  nodes: PropTypes.arrayOf(Node).isRequired,
+  closeFn: PropTypes.func.isRequired
+};
+
+export default VoteOnProposalForm;

--- a/saplings/circuits/src/components/forms/VoteOnProposalForm.scss
+++ b/saplings/circuits/src/components/forms/VoteOnProposalForm.scss
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.vote-on-proposal-form {
+  width: 100%;
+  height: 100%;
+
+  .form-header {
+    margin-top: 1rem;
+    height: 10%;
+
+    .form-title {
+      color: var(--color-primary);
+      font-size: 1.1rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .help-text {
+      color: var(--color-grey);
+      font-size: 0.8rem;
+    }
+  }
+
+  .proposal-review-wrapper {
+    height: 75%;
+    overflow-y: auto;
+  }
+
+  .form-footer {
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-light-grey);
+    height: 15%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .form-button {
+    height: 2.5rem;
+    border-radius: 5%;
+    width: fit-content;
+    background: transparent;
+    border: 1px solid inset var(--color-grey);
+    cursor: pointer;
+
+    &.accept {
+      background: var(--color-primary);
+      border: none;
+      color: var(--color-text-on-dark);
+    }
+
+    &.reject {
+      background: var(--color-attention);
+      color: var(--color-text-on-dark);
+      margin-right: 0.5rem;
+      border: none;
+    }
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .vote-on-proposal-form {
+    .form-header {
+      height: 15%;
+    }
+
+    .proposal-review-wrapper {
+      height: 70%;
+    }
+  }
+}

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -71,7 +71,8 @@ function Circuit(data) {
       votes: data.votes,
       requester: data.requester,
       requesterNodeID: data.requester_node_id,
-      proposalType: data.proposal_type
+      proposalType: data.proposal_type,
+      circuitHash: data.circuit_hash
     };
   } else {
     this.id = data.id;
@@ -85,7 +86,8 @@ function Circuit(data) {
       votes: [],
       requester: '',
       requesterNodeID: '',
-      proposalType: ''
+      proposalType: '',
+      circuitHash: ''
     };
   }
 }


### PR DESCRIPTION
This PR adds the capability to use the UI to vote on a circuit proposal. 

#### To test
1. Run:
```
docker-compose -f docker/docker-compose.yaml up --build
```

2. If you don't already have a open proposal created by the alpha node, create one via the UI or the CLI. You can find instructions on how to create a proposal via the UI [here](https://github.com/Cargill/splinter-ui/pull/30), and via the CLI [here](https://github.com/Cargill/splinter-ui/pull/23). 

3. To see the beta node UI go to: `localhost:3031`. Log in or register a new user.

4. Click on the `circuits` option in the left side menu, it will forward you to  `localhost:3031/circuits`. You should see in the circuit list the an open proposal. 
<img width="1268" alt="Screen Shot 2020-06-22 at 12 37 47 PM" src="https://user-images.githubusercontent.com/14094978/85318209-33260080-b485-11ea-8ee6-daf1d762c14e.png">

5. Click on the row for the proposal you want to vote on. You'll be forwarded to the circuit details page. The `Vote on proposal` button will be disabled until the user has active keys set in their profile. This is a temporary solution until a more robust strategy can be developed.

<img width="1268" alt="Screen Shot 2020-06-22 at 12 38 41 PM" src="https://user-images.githubusercontent.com/14094978/85318287-53ee5600-b485-11ea-8dfd-e2c457c0934f.png">

6. To set keys click in the "profile" icon in the bottom left corner of the screen to go to `localhost:3031/profile` and click the "+" button to add new keys:
<img width="1227" alt="Screen Shot 2020-06-21 at 11 21 39 AM" src="https://user-images.githubusercontent.com/14094978/85229772-65662e00-b3b1-11ea-8b15-cb6058c7c6db.png">

7. In the command line log into the generate-registry container to fetch bob's key:

```
docker-compose -f docker/docker-compose.yaml run generate-registry bash
cat /registry/bob.priv
cat /registry/bob.pub
```

8. Copy Bob's public and private key to the form and create the keys:
<img width="1268" alt="Screen Shot 2020-06-22 at 12 41 26 PM" src="https://user-images.githubusercontent.com/14094978/85318500-b5162980-b485-11ea-9a19-2de32c9b17f7.png">

9. Click on the key information to set it as active:
<img width="1268" alt="Screen Shot 2020-06-22 at 12 42 02 PM" src="https://user-images.githubusercontent.com/14094978/85318543-ca8b5380-b485-11ea-8676-e0ab502c4313.png">

10. Click on the `circuits` option in the left side menu, it will forward you to  `localhost:3031/circuits`. 

11. Click on the row with the proposal you want to vote on. In the circuit detail page notice that the `Vote of proposal` button is now active

<img width="1268" alt="Screen Shot 2020-06-22 at 12 43 36 PM" src="https://user-images.githubusercontent.com/14094978/85318667-03c3c380-b486-11ea-93f5-6aae7ae4dcd2.png">

12. Click on the `Vote on proposal` button to open the modal with the form.

<img width="1268" alt="Screen Shot 2020-06-22 at 12 44 44 PM" src="https://user-images.githubusercontent.com/14094978/85318765-2b1a9080-b486-11ea-88a7-c65230110042.png">

13. Review the proposal information one last time before submitting your vote.
<img width="1268" alt="Screen Shot 2020-06-22 at 12 45 58 PM" src="https://user-images.githubusercontent.com/14094978/85318871-57cea800-b486-11ea-9ffb-499b7f55a6f9.png">

14. If you accepted the proposal, refresh the page to that is is no longer a proposal, but a full circuit:
<img width="1268" alt="Screen Shot 2020-06-22 at 12 47 00 PM" src="https://user-images.githubusercontent.com/14094978/85318976-7fbe0b80-b486-11ea-987d-926fe8a1cd74.png">

15. If you reject the proposal you'll be redirected to the `localhost:3031/circuits`, as the proposal no longer exists. 


