### PR TITLE
Detail page fixes

### DIFF
--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
@@ -149,6 +149,18 @@ const NodesTable = ({ circuit, nodes }) => {
     return <div />;
   }
 
+  nodes.sort((nodeA, nodeB) => {
+    const nodeIdA = nodeA.identity.toLowerCase();
+    const nodeIdB = nodeB.identity.toLowerCase();
+    if (nodeIdA < nodeIdB) {
+      return -1;
+    }
+    if (nodeIdA > nodeIdB) {
+      return 1;
+    }
+    return 0;
+  });
+
   let rows = [
     <tr>
       <td colSpan="5" className="no-nodes-msg">

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
@@ -22,7 +22,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faQuestionCircle,
   faArrowLeft,
-  faExclamationTriangle
+  faExclamationTriangle,
+  faCaretDown,
+  faCaretRight
 } from '@fortawesome/free-solid-svg-icons';
 import PropTypes from 'prop-types';
 import { useParams, Link } from 'react-router-dom';
@@ -182,6 +184,7 @@ const NodesTable = ({ circuit, nodes }) => {
         }, []);
       }
 
+      let toggledIcon = <FontAwesomeIcon icon={faCaretRight} />;
       let detailsRow = '';
       if (toggledRow === idx) {
         detailsRow = (
@@ -195,6 +198,7 @@ const NodesTable = ({ circuit, nodes }) => {
             </td>
           </tr>
         );
+        toggledIcon = <FontAwesomeIcon icon={faCaretDown} />;
       }
 
       return [
@@ -208,7 +212,10 @@ const NodesTable = ({ circuit, nodes }) => {
             }
           }}
         >
-          <td>{node.identity}</td>
+          <td>
+            <span className="toggle">{toggledIcon}</span>
+            {node.identity}
+          </td>
           <td>{node.displayName}</td>
           <td>
             {node.metadata.company || node.metadata.organization || 'N/A'}

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
@@ -124,6 +124,10 @@
           color: var(--color-secondary);
         }
       }
+
+      .toggle {
+        margin-right: 0.25rem;
+      }
     }
 
     .service-details-row {


### PR DESCRIPTION
- Sort the nodes in the details page, so order is preserved across data refreshes
- Add a caret toggle indicator for the service information