### PR TITLE
Rename metadata to application metadata

### DIFF
--- a/saplings/circuits/src/components/ProposalReview.js
+++ b/saplings/circuits/src/components/ProposalReview.js
@@ -70,7 +70,7 @@ const ProposalReview = ({
         <div className="field-value">{comments}</div>
       </div>
       <div class-name="metadata-container">
-        <div className="title">Metadata</div>
+        <div className="title">Application metadata</div>
         {metadata.encoding && (
           <div>
             <div className="label">Encoding</div>

--- a/saplings/circuits/src/components/forms/ProposeCircuitForm.js
+++ b/saplings/circuits/src/components/forms/ProposeCircuitForm.js
@@ -702,14 +702,14 @@ export function ProposeCircuitForm() {
           </div>
         </div>
       </Step>
-      <Step step={4} label="Add metadata">
+      <Step step={4} label="Add application metadata">
         <div className="step-header">
-          <div className="step-title">Add metadata</div>
+          <div className="step-title">Add application metadata</div>
           <div className="help-text">
-            Add metatada for the circuit. This data will be serialized before
-            being included in the circuit proposal. The metadata is opaque to
-            the splinter daemon, and it is only consumed by client applications
-            for the circuit.
+            Add application metatada for the circuit. This data will be
+            serialized before being included in the circuit proposal. The
+            metadata is opaque to the splinter daemon, and it is only consumed
+            by client applications for the circuit.
           </div>
         </div>
         <div className="propose-form-wrapper metatada-wrapper">


### PR DESCRIPTION
Rename the sections from "add metadata" to "add application metadata", to improve clarity.