### PR TITLE
Metadata details display

### DIFF
--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
@@ -34,6 +34,7 @@ import { Circuit } from '../../data/circuits';
 import { useCircuitState } from '../../state/circuits';
 import { getNodeRegistry } from '../../api/splinter';
 import ServiceDetails from './ServiceDetails';
+import CircuitMetaData from './CircuitMetaData';
 import VoteButton from './VoteButton';
 import { useLocalNodeState } from '../../state/localNode';
 import { OverlayModal } from '../OverlayModal';
@@ -122,25 +123,28 @@ const CircuitDetails = () => {
           </div>
         </div>
       </div>
-      <div className="main-content">
-        <div className="midContent">
-          <div className="circuit-stats">
-            <div className="stat total-circuits">
-              <span className="stat-count circuits-count">
-                {circuit.members.length}
-              </span>
-              Nodes
-            </div>
-            <div className="stat action-required">
-              <span className="stat-count action-required-count">
-                {circuit.roster.length}
-              </span>
-              Services
+      <div className="detail-content">
+        <div className="main-content">
+          <div className="midContent">
+            <div className="circuit-stats">
+              <div className="stat total-circuits">
+                <span className="stat-count circuits-count">
+                  {circuit.members.length}
+                </span>
+                Nodes
+              </div>
+              <div className="stat action-required">
+                <span className="stat-count action-required-count">
+                  {circuit.roster.length}
+                </span>
+                Services
+              </div>
             </div>
           </div>
-        </div>
 
-        <NodesTable circuit={circuit} nodes={nodes} />
+          <NodesTable circuit={circuit} nodes={nodes} />
+        </div>
+        <CircuitMetaData circuit={circuit} />
       </div>
       <OverlayModal open={modalActive}>
         <VoteOnProposalForm

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
@@ -128,9 +128,9 @@
       }
       td {
         cursor: pointer;
-        font-size: 0.8rem;
+        font-size: 1rem;
         vertical-align: middle;
-        padding: 2rem 2rem 2rem 0;
+        padding: 1rem 1rem 1rem 0;
       }
 
       .toggle {

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
@@ -71,9 +71,25 @@
   }
 }
 
-.table-container {
+.detail-content {
+  display: flex;
+  flex-direction: row;
+
+  .main-content {
+    flex: 2;
+    margin: 3rem 1.5rem 0;
+  }
+
+  .circuit-details {
+    flex: 1;
+    margin: 3rem 1.5rem 0 1.5rem;
+    overflow: auto;
+    height: 100%;
+  }
+}
+
+.nodes-content {
   overflow:auto;
-  margin-top: 3rem;
 
   .nodes-table {
     width: 100%;

--- a/saplings/circuits/src/components/circuitDetails/CircuitMetaData.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitMetaData.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+
+import { Circuit } from '../../data/circuits';
+import './CircuitMetaData.scss';
+
+const MetadataRows = ({ metadata }) => {
+  let metadataDetails;
+  if (typeof metadata === 'object') {
+    metadataDetails = (
+      <table>
+        <tbody>
+          {Object.entries(metadata)
+            .filter(([key]) => {
+              return Object.prototype.hasOwnProperty.call(metadata, key);
+            })
+            .map(([key, value]) => {
+              return (
+                <tr key={key}>
+                  <td>{key}</td>
+                  <td>{value}</td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    );
+  } else {
+    metadataDetails = (
+      <div className={metadata ? 'binary-metadata' : 'no-metadata'}>
+        {metadata ? 'Binary Data' : 'None'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="metadata">
+      <div className="metadata-title">Metadata</div>
+      {metadataDetails}
+    </div>
+  );
+};
+
+MetadataRows.propTypes = {
+  metadata: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
+};
+
+const CircuitMetaData = ({ circuit }) => {
+  return (
+    <div className="circuit-details">
+      <div className="circuit-details-header">
+        Circuit Details
+        <span>
+          <FontAwesomeIcon icon={faQuestionCircle} />
+        </span>
+      </div>
+      <div className="comments">
+        <div className="comments-title">Comments</div>
+        <div className={!circuit.comments ? 'no-comments' : ''}>
+          {circuit.comments ? circuit.comments.toString() : 'None'}
+        </div>
+      </div>
+      <MetadataRows metadata={circuit.applicationMetadata} />
+    </div>
+  );
+};
+
+CircuitMetaData.propTypes = {
+  circuit: PropTypes.instanceOf(Circuit).isRequired
+};
+
+export default CircuitMetaData;

--- a/saplings/circuits/src/components/circuitDetails/CircuitMetaData.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitMetaData.scss
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+.circuit-details {
+
+  .circuit-details-header {
+    font-size: 1.5em;
+    line-height: 1.75rem;
+    text-align: center;
+    margin-bottom: 2rem;
+
+    span {
+      margin-left: .25rem;
+    }
+  }
+
+  .comments {
+    .comments-title {
+      font-size: 1.5rem;
+      border-bottom: 1px var(--color-light-grey) solid;
+    }
+
+    .no-comments {
+      color: var(--color-light-grey);
+    }
+
+    margin-bottom: 1.5rem;
+  }
+
+  .metadata {
+    .metadata-title {
+      font-size: 1.5rem;
+    }
+
+    .binary-metadata {
+    }
+
+    .no-metadata {
+      color: var(--color-light-grey);
+    }
+
+    table {
+      height: 100%;
+      width: 100%;
+      border-collapse: collapse;
+      border-top: 1px var(--color-light-grey) solid;
+
+      td:first-child {
+        align: left;
+        font-weight: normal;
+        border-right: 1px var(--color-light-grey) solid;
+        padding: 0.25rem;
+      }
+
+      td {
+        align: left;
+        padding: 0.25rem;
+      }
+    }
+  }
+}

--- a/saplings/circuits/src/components/forms/VoteOnProposalForm.js
+++ b/saplings/circuits/src/components/forms/VoteOnProposalForm.js
@@ -96,7 +96,7 @@ const VoteOnProposalForm = ({ proposal, nodes, closeFn }) => {
           members={nodes}
           services={proposal.roster}
           comments={proposal.comments}
-          metadata={{ metadata: proposal.applicationMetadata }}
+          metadata={{ metadata: proposal.encodedApplicationMetadata }}
           managementType={proposal.managementType}
         />
       </div>

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -40,19 +40,25 @@ const argsToObject = coll => {
   }, {});
 };
 
-class Service {
-  constructor(jsonSource) {
-    if (jsonSource) {
-      this.serviceId = jsonSource.service_id;
-      this.serviceType = jsonSource.service_type;
-      this.allowedNodes = jsonSource.allowed_nodes;
-      this.arguments = argsToObject(jsonSource.arguments);
-    } else {
-      this.serviceId = '';
-      this.serviceType = '';
-      this.allowedNodes = [];
-      this.arguments = {};
     }
+  }
+};
+
+function Service(jsonSource) {
+  if (!(this instanceof Service)) {
+    return new Service(jsonSource);
+  }
+
+  if (jsonSource) {
+    this.serviceId = jsonSource.service_id;
+    this.serviceType = jsonSource.service_type;
+    this.allowedNodes = jsonSource.allowed_nodes;
+    this.arguments = argsToObject(jsonSource.arguments);
+  } else {
+    this.serviceId = '';
+    this.serviceType = '';
+    this.allowedNodes = [];
+    this.arguments = {};
   }
 }
 

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -63,6 +63,9 @@ function Service(jsonSource) {
 }
 
 function Circuit(data) {
+  if (!(this instanceof Circuit)) {
+    return new Circuit(data);
+  }
   if (data.proposal_type) {
     this.id = data.circuit_id;
     this.status = 'Pending';

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import yaml from 'js-yaml';
+
 import Paging from './paging';
 
 /**
@@ -40,6 +42,18 @@ const argsToObject = coll => {
   }, {});
 };
 
+const metadataFromJson = encoded => {
+  let asString = encoded;
+  try {
+    const unencoded = Buffer.from(encoded, 'hex');
+    asString = unencoded.toString();
+    return JSON.parse(asString);
+  } catch (jsonException) {
+    // try yaml
+    try {
+      return yaml.safeLoad(asString);
+    } catch (yamlException) {
+      return encoded;
     }
   }
 };
@@ -74,7 +88,10 @@ function Circuit(data) {
     });
     this.roster = data.circuit.roster.map(s => new Service(s));
     this.managementType = data.circuit.management_type;
-    this.applicationMetadata = data.circuit.application_metadata;
+    this.applicationMetadata = metadataFromJson(
+      data.circuit.application_metadata
+    );
+    this.encodedApplicationData = data.circuit.application_metadata;
     this.comments = data.circuit.comments;
     this.proposal = {
       votes: data.votes,
@@ -89,7 +106,8 @@ function Circuit(data) {
     this.members = data.members;
     this.roster = data.roster.map(s => new Service(s));
     this.managementType = data.management_type;
-    this.applicationMetadata = data.application_metadata;
+    this.applicationMetadata = metadataFromJson(data.application_metadata);
+    this.encodedApplicationData = data.application_metadata;
     this.comments = 'N/A';
     this.proposal = {
       votes: [],

--- a/saplings/circuits/src/data/nodeRegistry.js
+++ b/saplings/circuits/src/data/nodeRegistry.js
@@ -15,6 +15,10 @@
  */
 
 function Node(data) {
+  if (!(this instanceof Node)) {
+    return new Node(data);
+  }
+
   this.identity = data.identity;
   this.endpoints = data.endpoints;
   this.displayName = data.display_name;


### PR DESCRIPTION
This UI alters the circuit details to display the comments and the metadata (if parseable) in the right third of the screen:
![Screen Shot 2020-08-04 at 1 16 36 PM](https://user-images.githubusercontent.com/282233/89329700-c772ae00-d654-11ea-879b-289db6d93237.png)

This can be tested by proposing a circuit, and adding either JSON metadata or YAML metadata (both will parse).