### PR TITLE
Use index instead of key for service arg wrapper

### DIFF
--- a/saplings/circuits/src/components/ServiceCard.js
+++ b/saplings/circuits/src/components/ServiceCard.js
@@ -415,7 +415,7 @@ const ServiceCard = ({
     return argumentsState.arguments.map((arg, i) => {
       return (
         <div
-          key={`args-${arg.key}`}
+          key={`args-${arg.index}`}
           className="arguments-input-wrapper flex-input"
         >
           <input


### PR DESCRIPTION
The service argument input wrapper is now keyed by the argument's index
instead of its key. This is to fix a small bug that caused the input
field to lose focus while adding the service argument key. Whenever the
user would type a character for the key name, the argument wrapper's key
would change causing the wrapper to rerender and the input to lose focus.
As a result you could only input one character at a time when entering a
key name.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>