### PR TITLE
Add cancel to MultiStep form

### DIFF
--- a/saplings/circuits/src/components/forms/MultiStepForm.js
+++ b/saplings/circuits/src/components/forms/MultiStepForm.js
@@ -31,6 +31,7 @@ export function Step({ step, currentStep, children }) {
 export function MultiStepForm({
   formName,
   handleSubmit,
+  handleCancel,
   style,
   disabled,
   error,
@@ -114,11 +115,13 @@ export function MultiStepForm({
           )}
         </form>
         <div className="actions">
-          {step > 1 && (
-            <button className="form-button" type="button" onClick={previous}>
-              Previous
-            </button>
-          )}
+          <button
+            className="form-button"
+            type="button"
+            onClick={step > 1 ? previous : handleCancel}
+          >
+            {step > 1 ? 'Previous' : 'Cancel'}
+          </button>
           {step < children.length && (
             <button
               type="button"
@@ -160,6 +163,7 @@ Step.defaultProps = {
 MultiStepForm.propTypes = {
   formName: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
+  handleCancel: PropTypes.func.isRequired,
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   disabled: PropTypes.bool,
   error: PropTypes.bool,

--- a/saplings/circuits/src/components/forms/propose_circuit/index.js
+++ b/saplings/circuits/src/components/forms/propose_circuit/index.js
@@ -516,6 +516,7 @@ export function ProposeCircuitForm() {
     <MultiStepForm
       formName="Propose Circuit"
       handleSubmit={handleSubmit}
+      handleCancel={() => history.push(`/circuits`)}
       isStepValidFn={stepNumber => stepValidationFn(stepNumber)}
     >
       <Step step={1} label="Add nodes">


### PR DESCRIPTION
This change adds a cancel button to the multi step form, to allow callers to perform navigation or cleanup actions if the form is abandoned.

The propose circuit form can navigate back to the circuit list, on cancel.
