### PR TITLE
Fix table container height

### DIFF
--- a/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
+++ b/saplings/circuits/src/components/circuitsTable/CircuitsTable.scss
@@ -17,6 +17,7 @@
 .table-container {
   overflow:auto;
   margin-top: 3rem;
+  height: 100vh;
 
   .circuits-table {
     width: 100%;


### PR DESCRIPTION
This change fixes an issue with the filter drop-down being cut off when the table has few to no items in it.
