### PR TITLE
Initial OAuth login sapling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /sapling-dev-server/circuits
 /sapling-dev-server/register-login.js
 /sapling-dev-server/profile
+/sapling-dev-server/oauth-login
 
 /saplings/circuits/src/compiled_protos.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ jobs:
     - stage: Lint Register-Login Sapling
       script:
         - docker-compose -f docker/compose/run-lint.yaml up --abort-on-container-exit lint-register-login-sapling
+    - stage: Lint OAuth-Login Sapling
+      script:
+        - docker-compose -f docker/compose/run-lint.yaml up --abort-on-container-exit lint-oauth-login-sapling
 
     - stage: Publish artifacts
       language: generic

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ RUN cd /saplings/register-login && \
   npm install && \
   npm run deploy
 
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/oauth-login
+RUN cd /saplings/oauth-login && \
+  npm install && \
+  npm run deploy
+
 ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/profile
 RUN cd /saplings/profile && \
   npm install && \

--- a/docker/compose/run-lint.yaml
+++ b/docker/compose/run-lint.yaml
@@ -43,3 +43,10 @@ services:
       dockerfile: ./test/Dockerfile
     image: register-login-sapling:${ISOLATION_ID}
     command: npm run lint
+
+  lint-oauth-login-sapling:
+    build:
+      context: ../../saplings/oauth-login
+      dockerfile: ./test/Dockerfile
+    image: oauth-login-sapling:${ISOLATION_ID}
+    command: npm run lint

--- a/sapling-dev-server/Dockerfile
+++ b/sapling-dev-server/Dockerfile
@@ -28,6 +28,11 @@ RUN cd /saplings/register-login && \
   npm install && \
   npm run deploy
 
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/oauth-login
+RUN cd /saplings/oauth-login && \
+  npm install && \
+  npm run deploy
+
 ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/profile
 RUN cd /saplings/profile && \
   npm install && \

--- a/sapling-dev-server/configSaplings
+++ b/sapling-dev-server/configSaplings
@@ -16,5 +16,15 @@
    ],
    "styleFiles": [],
    "workerFiles": []
- }
+  },
+  {
+    "namespace": "oauth-login",
+    "runtimeFiles": [
+      "localhost:3030/sapling-dev-server/oauth-login/static/js/oauth-login.js"
+    ],
+    "styleFiles": [
+      "localhost:3030/sapling-dev-server/oauth-login/static/css/oauth-login.css"
+    ],
+    "workerFiles": []
+  }
 ]

--- a/sapling-dev-server/oauth-login.js
+++ b/sapling-dev-server/oauth-login.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+window.$CANOPY.registerConfigSapling('oauth-login', () => {
+  console.log('Registering OAuth Login Sapling');
+
+  if (window.location.pathname === '/oauth-login') {
+    window.$CANOPY.registerApp(function (domNode) {
+      console.log('Rendering OAuth-Login JS App');
+      domNode.innerHTML = `<h1>OAuth Login<h1>`;
+    });
+  }
+});

--- a/saplings/oauth-login/.babelrc
+++ b/saplings/oauth-login/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/saplings/oauth-login/.eslintrc
+++ b/saplings/oauth-login/.eslintrc
@@ -1,0 +1,24 @@
+{
+  "env": {
+    "es6": true,
+    "jest": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "extends": ["airbnb", "plugin:prettier/recommended"],
+  "rules": {
+    "react/jsx-filename-extension": 0,
+    "react/prefer-stateless-function": 0,
+    "import/prefer-default-export": 0
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["src"]
+      },
+      "webpack": "./webpack.config.js"
+    }
+  }
+}

--- a/saplings/oauth-login/.prettierignore
+++ b/saplings/oauth-login/.prettierignore
@@ -1,0 +1,15 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build/*

--- a/saplings/oauth-login/.prettierrc
+++ b/saplings/oauth-login/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "proseWrap": always
+}

--- a/saplings/oauth-login/package.json
+++ b/saplings/oauth-login/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "oauth-login-sapling",
+  "private": true,
+  "version": "0.0.0-alpha",
+  "license": "Apache-2.0",
+  "author": "Cargill Incorporated",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "webpack",
+    "bundle": "webpack --mode=development",
+    "package": "rm -rf package && mkdir package && cp -r ./build/static package && cp -r images package && tar -jcvf oauth-login_$npm_config_sapling_version.sapling package",
+    "add-to-canopy": "mkdir -p ../../sapling-dev-server/oauth-login && cp -r ./build/static ../../sapling-dev-server/oauth-login",
+    "deploy": "npm run build && npm run add-to-canopy",
+    "deploy-local": "npm run bundle && npm run add-to-canopy",
+    "watch": "nodemon --ext js,scss,ts,css --watch src --exec npm run deploy-local",
+    "lint": "eslint ."
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "dependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "splinter-saplingjs": "github:cargill/splinter-saplingjs#master"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.10.5",
+    "@babel/preset-env": "^7.10.4",
+    "@babel/preset-react": "^7.10.4",
+    "babel-loader": "^8.1.0",
+    "css-loader": "^4.1.0",
+    "eslint": "^6.6.0",
+    "eslint-config-airbnb": "18.0.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-import-resolver-webpack": "^0.12.2",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "http-server": "^0.12.1",
+    "mini-css-extract-plugin": "^0.9.0",
+    "mini-svg-data-uri": "^1.2.3",
+    "node-sass": "^4.13.1",
+    "nodemon": "^2.0.2",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^1.18.2",
+    "resolve-url-loader": "^3.1.1",
+    "sass": "^1.26.10",
+    "sass-loader": "^9.0.2",
+    "style-loader": "^1.2.1",
+    "svg-inline-loader": "^0.8.2",
+    "url-loader": "^4.1.0",
+    "webpack": "^4.44.0",
+    "webpack-cli": "^3.3.12"
+  }
+}

--- a/saplings/oauth-login/public/index.html
+++ b/saplings/oauth-login/public/index.html
@@ -1,0 +1,31 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Oauth-Login sapling" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <title>OAuth Login</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+
+</html>

--- a/saplings/oauth-login/public/manifest.json
+++ b/saplings/oauth-login/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "short_name": "Oauth-Login",
+  "name": "Oauth-Login Sapling",
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#222325"
+}

--- a/saplings/oauth-login/src/App.css
+++ b/saplings/oauth-login/src/App.css
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.oauth-login-app {
+  background-color: #222325;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+}

--- a/saplings/oauth-login/src/App.js
+++ b/saplings/oauth-login/src/App.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import './App.css';
+
+import { OAuthLoginForm } from './forms/OAuthLoginForm';
+
+function App() {
+  return (
+    <div className="oauth-login-app">
+      <OAuthLoginForm />
+    </div>
+  );
+}
+
+export default App;

--- a/saplings/oauth-login/src/components/OAuthLoginButton.js
+++ b/saplings/oauth-login/src/components/OAuthLoginButton.js
@@ -15,16 +15,19 @@
  */
 
 import React from 'react';
-import './App.css';
+import './OAuthLoginButton.scss';
 
-import { OAuthLoginButton } from './components/OAuthLoginButton';
-
-function App() {
+export function OAuthLoginButton() {
   return (
-    <div className="oauth-login-app">
-      <OAuthLoginButton />
+    <div className="oauth-login-button-wrapper">
+      <div className="btn-header">
+        <div className="btn-title">Log In</div>
+      </div>
+      <div className="btn-wrapper">
+        <button type="button" className="button btn log-in">
+          Log in using OAuth2.0
+        </button>
+      </div>
     </div>
   );
 }
-
-export default App;

--- a/saplings/oauth-login/src/components/OAuthLoginButton.scss
+++ b/saplings/oauth-login/src/components/OAuthLoginButton.scss
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.oauth-login-button-wrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  background-color: #efefef;
+  width: fit-content;
+
+  .btn-header {
+    height: 15%;
+    margin: 1rem 0rem 2rem 0rem;
+
+    .btn-title {
+      color: var(--color-primary);
+      font-size: 30px;
+      display: flex;
+      justify-content: center;
+    }
+  }
+
+  .btn-wrapper {
+    margin-top: 0.3rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+
+    .btn {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 3rem;
+      border-radius: 5%;
+      width: fit-content;
+      background: var(--color-secondary);
+      border: 1px solid inset var(--color-grey);
+      cursor: pointer;
+    }
+  }
+}

--- a/saplings/oauth-login/src/index.css
+++ b/saplings/oauth-login/src/index.css
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+  margin: 0;
+}

--- a/saplings/oauth-login/src/index.js
+++ b/saplings/oauth-login/src/index.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  registerConfigSapling,
+  registerApp,
+  hideCanopy
+} from 'splinter-saplingjs';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
+import App from './App';
+
+registerConfigSapling('oauth-login', () => {
+  if (window.location.pathname === '/oauth-login') {
+    hideCanopy();
+    registerApp(domNode => {
+      ReactDOM.render(<App />, domNode);
+    });
+  }
+});

--- a/saplings/oauth-login/test/Dockerfile
+++ b/saplings/oauth-login/test/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for running unit tests and lint on the oauth-login sapling
+FROM node:lts-alpine
+
+WORKDIR /saplings/oauth-login
+
+COPY package*.json ./
+
+RUN apk add git
+
+# Gives npm permission to run the prepare script in splinter-canopyjs as root
+RUN npm config set unsafe-perm true && npm install
+
+COPY . .

--- a/saplings/oauth-login/webpack.config.js
+++ b/saplings/oauth-login/webpack.config.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const svgToMiniDataURI = require('mini-svg-data-uri');
+
+module.exports = (env, argv) => {
+  const isDevelMode = argv.mode === 'development';
+
+  const config = {
+    entry: [`${__dirname}/src/index.js`],
+    output: {
+      filename: 'oauth-login.js',
+      path: path.resolve(__dirname, 'build/static/js')
+    },
+    resolve: {
+      alias: {
+        App: path.resolve(__dirname, 'src')
+      }
+    },
+    module: {
+      rules: [
+        // jsx, etc
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'babel-loader'
+        },
+        {
+          test: /\.css$/,
+          use: [
+            'style-loader',
+            MiniCssExtractPlugin.loader,
+            {
+              loader: 'css-loader',
+              options: {
+                importLoaders: 2,
+                sourceMap: isDevelMode
+              }
+            }
+          ]
+        },
+        {
+          // styles
+          test: /\.(sass|scss)$/,
+          use: [
+            'style-loader',
+            MiniCssExtractPlugin.loader,
+            {
+              loader: 'css-loader',
+              options: {
+                importLoaders: 2,
+                sourceMap: isDevelMode
+              }
+            },
+            {
+              loader: require.resolve('resolve-url-loader'),
+              options: {
+                sourceMap: isDevelMode
+              }
+            },
+            {
+              loader: 'sass-loader',
+              options: {
+                sourceMap: isDevelMode
+              }
+            }
+          ]
+        },
+        {
+          test: /\.svg$/i,
+          use: [
+            {
+              loader: 'url-loader',
+              options: {
+                generator: context => svgToMiniDataURI(context.toString())
+              }
+            }
+          ]
+        }
+      ]
+    },
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          css: {
+            test: /\.(css|sass|scss)$/,
+            name: 'oauth-login',
+            chunks: 'all',
+            minChunks: 2
+          }
+        }
+      }
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        // this file path is relative to the js file output
+        filename: '../css/oauth-login.css'
+      })
+    ]
+  };
+
+  if (isDevelMode) {
+    config.devtool = 'source-map';
+  }
+
+  return config;
+};


### PR DESCRIPTION
Adds an initial login sapling (intended to be used for OAuth) with a simple form that currently isn't functional. 
To navigate to this sapling, run `docker-compose up --build`, then after signing in through the current login page, go to `localhost:3030/oauth-login`.  