### PR TITLE
Auth sapling configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,8 @@
 **/build
 **/dist
 **/package-lock.json
+
+/sapling-dev-server/circuits
+/sapling-dev-server/register-login.js
+/sapling-dev-server/profile
+/sapling-dev-server/oauth-login

--- a/Dockerfile-biome
+++ b/Dockerfile-biome
@@ -36,16 +36,13 @@ RUN npm config set unsafe-perm true
 
 COPY saplings saplings
 COPY sapling-dev-server sapling-dev-server
+COPY sapling-dev-server/configSaplings-biome sapling-dev-server/configSaplings
 
 ARG PUBLIC_URL_PARTIAL
 ENV PUBLIC_URL $PUBLIC_URL_PARTIAL
 
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/login
 RUN cd /saplings/register-login && \
-  npm install && \
-  npm run deploy
-
-ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/oauth-login
-RUN cd /saplings/oauth-login && \
   npm install && \
   npm run deploy
 

--- a/Dockerfile-oauth
+++ b/Dockerfile-oauth
@@ -1,0 +1,87 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Canopy build stage
+FROM node:lts-alpine as canopy-app-build-stage
+
+RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
+WORKDIR /splinter_ui
+COPY app/package*.json ./
+RUN npm config set unsafe-perm true && npm install
+COPY app .
+ENV REACT_APP_SPLINTER_URL "/splinterd"
+ENV REACT_APP_SAPLING_URL "/sapling-dev-server"
+RUN yarn build
+WORKDIR /splinter_ui/build
+ARG REPO_VERSION
+RUN tar c -z . -f ../splinter_ui_v${REPO_VERSION}.tar.gz
+
+# Sapling build stage
+FROM node:lts-alpine as sapling-build-stage
+
+RUN apk update && apk add git
+
+RUN npm config set unsafe-perm true
+
+COPY saplings saplings
+COPY sapling-dev-server sapling-dev-server
+COPY sapling-dev-server/configSaplings-oauth sapling-dev-server/configSaplings
+
+ARG PUBLIC_URL_PARTIAL
+ENV PUBLIC_URL $PUBLIC_URL_PARTIAL
+
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/login
+RUN cd /saplings/oauth-login && \
+  npm install && \
+  npm run deploy
+
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/profile
+RUN cd /saplings/profile && \
+  npm install && \
+  npm run deploy
+
+ENV PUBLIC_URL ${PUBLIC_URL_PARTIAL}/circuits
+RUN cd /saplings/circuits && \
+  npm install && \
+  npm run deploy
+
+WORKDIR sapling-dev-server
+ARG REPO_VERSION
+RUN tar c -z . -f ../splinter_saplings_v${REPO_VERSION}.tar.gz
+
+# prod stage
+FROM httpd:2.4 as prod-stage
+
+COPY --from=canopy-app-build-stage /splinter_ui/splinter_ui_v*.tar.gz /tmp
+RUN tar -xzvf /tmp/splinter_ui_*.tar.gz -C /usr/local/apache2/htdocs/
+
+COPY --from=sapling-build-stage /splinter_saplings_v*.tar.gz /tmp
+RUN mkdir /usr/local/apache2/htdocs/sapling-dev-server
+RUN tar -xzvf /tmp/splinter_saplings_*.tar.gz \
+  -C /usr/local/apache2/htdocs/sapling-dev-server/
+
+COPY /configs/apache/httpd.conf /usr/local/apache2/conf/httpd.conf
+
+RUN echo "\
+  \n\
+  LoadModule headers_module modules/mod_headers.so\n\
+  ProxyPass /splinterd \${SPLINTER_URL}\n\
+  ProxyPassReverse /splinterd \${SPLINTER_URL}\n\
+  <Directory "/usr/local/apache2/htdocs/sapling-dev-server">\n\
+   Header set Access-Control-Allow-Origin "*"\n\
+  </Directory>\n\
+  \n\
+  " >>/usr/local/apache2/conf/httpd.conf
+
+EXPOSE 80/tcp

--- a/docker-compose-biome.yaml
+++ b/docker-compose-biome.yaml
@@ -74,7 +74,7 @@ services:
   splinter-ui-alpha:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile-biome
       args:
         REPO_VERSION: ${REPO_VERSION}
     image: ${NAMESPACE}splinter-ui:${ISOLATION_ID}
@@ -138,7 +138,7 @@ services:
   splinter-ui-beta:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile-biome
       args:
         REPO_VERSION: ${REPO_VERSION}
     image: ${NAMESPACE}splinter-ui:${ISOLATION_ID}

--- a/docker-compose-oauth.yaml
+++ b/docker-compose-oauth.yaml
@@ -1,0 +1,199 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: '3.6'
+
+volumes:
+  contracts:
+  registry:
+
+services:
+
+  # ---== alpha node ==---
+
+  splinterd-alpha:
+    image: splintercommunity/splinterd:experimental
+    container_name: splinterd-alpha
+    hostname: splinterd-alpha
+    expose:
+      - 8044
+      - 8085
+    ports:
+      - "8044:8044"
+      - "8085:8085"
+    entrypoint: |
+      bash -c "
+        until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
+        if [ ! -f /etc/splinter/certs/private/server.key ]
+        then
+          splinter-cli cert generate --force
+        fi && \
+        splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
+        splinterd -vv \
+        --registries http://registry-server:80/registry.yaml \
+        --rest-api-endpoint 0.0.0.0:8085 \
+        --network-endpoints tcps://0.0.0.0:8044 \
+        --advertised-endpoints tcps://splinterd-alpha:8044 \
+        --node-id alpha-node-000 \
+        --service-endpoint tcp://0.0.0.0:8043 \
+        --storage yaml \
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
+        --enable-biome \
+        --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
+        --tls-insecure
+      "
+  splinter-db-alpha:
+    image: postgres
+    container_name: splinter-db-alpha
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: splinter
+
+  splinter-ui-alpha:
+    build:
+      context: .
+      dockerfile: Dockerfile-oauth
+      args:
+        REPO_VERSION: ${REPO_VERSION}
+    image: ${NAMESPACE}splinter-ui:${ISOLATION_ID}
+    container_name: splinter-ui-alpha
+    expose:
+      - 80
+    ports:
+      - '3030:80'
+    environment:
+      SPLINTER_URL: 'http://splinterd-alpha:8085'
+
+# ---== beta node ==---
+
+  splinterd-beta:
+    image: splintercommunity/splinterd:experimental
+    container_name: splinterd-beta
+    hostname: splinterd-beta
+    expose:
+      - 8044
+      - 8055
+    ports:
+      - "8045:8044"
+    entrypoint: |
+      bash -c "
+        until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
+        if [ ! -f /etc/splinter/certs/private/server.key ]
+        then
+          splinter-cli cert generate --force
+        fi && \
+        splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
+        splinterd -vv \
+        --registries http://registry-server:80/registry.yaml \
+        --rest-api-endpoint 0.0.0.0:8085 \
+        --network-endpoints tcps://0.0.0.0:8044 \
+        --advertised-endpoints tcps://splinterd-beta:8044 \
+        --node-id beta-node-000 \
+        --service-endpoint tcp://0.0.0.0:8043 \
+        --storage yaml \
+        --tls-client-cert /etc/splinter/certs/client.crt \
+        --tls-client-key /etc/splinter/certs/private/client.key \
+        --tls-server-cert /etc/splinter/certs/server.crt \
+        --tls-server-key /etc/splinter/certs/private/server.key \
+        --enable-biome \
+        --database postgres://admin:admin@splinter-db-beta:5432/splinter \
+        --tls-insecure
+      "
+  splinter-db-beta:
+    image: postgres
+    container_name: splinter-db-beta
+    restart: always
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: splinter
+
+  splinter-ui-beta:
+    build:
+      context: .
+      dockerfile: Dockerfile-oauth
+      args:
+        REPO_VERSION: ${REPO_VERSION}
+    image: ${NAMESPACE}splinter-ui:${ISOLATION_ID}
+    container_name: splinter-ui-beta
+    expose:
+      - 80
+    ports:
+      - '3031:80'
+    environment:
+      SPLINTER_URL: 'http://splinterd-beta:8085'
+
+# ---== shared services ==---
+
+  generate-registry:
+    image: splintercommunity/splinter-cli:master
+    volumes:
+      - registry:/registry
+    command: |
+      bash -c "
+        if [ ! -f /registry/registry.yaml ]
+        then
+          # generate keys
+          splinter admin keygen alice -d /registry
+          splinter admin keygen bob -d /registry
+          # check if splinterd-alpha is available
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 200 ]] ; do
+             >&2 echo \"splinterd is unavailable - sleeping\"
+             sleep 1
+          done
+          # check if splinterd-beta is available
+          while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 200 ]] ; do
+             >&2 echo \"splinterd is unavailable - sleeping\"
+             sleep 1
+          done
+          # build the registry
+          splinter registry build \
+            http://splinterd-alpha:8085 \
+            --file /registry/registry.yaml \
+            --key-file /registry/alice.pub \
+            --metadata organization='Alpha'
+          splinter registry build \
+            http://splinterd-beta:8085 \
+            --file /registry/registry.yaml \
+            --key-file /registry/bob.pub \
+            --metadata organization='Beta'
+        fi
+      "
+
+  registry-server:
+    image: httpd:2.4
+    container_name: registry-server
+    restart: always
+    expose:
+      - 80
+    ports:
+        - "8099:80"
+    volumes:
+      - registry:/usr/local/apache2/htdocs

--- a/sapling-dev-server/configSaplings-biome
+++ b/sapling-dev-server/configSaplings-biome
@@ -16,15 +16,5 @@
    ],
    "styleFiles": [],
    "workerFiles": []
-  },
-  {
-    "namespace": "oauth-login",
-    "runtimeFiles": [
-      "localhost:3030/sapling-dev-server/oauth-login/static/js/oauth-login.js"
-    ],
-    "styleFiles": [
-      "localhost:3030/sapling-dev-server/oauth-login/static/css/oauth-login.css"
-    ],
-    "workerFiles": []
   }
 ]

--- a/sapling-dev-server/configSaplings-oauth
+++ b/sapling-dev-server/configSaplings-oauth
@@ -1,0 +1,22 @@
+[
+  {
+    "namespace": "profile",
+    "runtimeFiles": [
+      "localhost:3030/sapling-dev-server/profile/js/profile.js"
+    ],
+    "styleFiles": [
+      "localhost:3030/sapling-dev-server/profile/css/profile.css"
+    ],
+    "workerFiles": []
+  },
+  {
+    "namespace": "login",
+    "runtimeFiles": [
+      "localhost:3030/sapling-dev-server/oauth-login/static/js/oauth-login.js"
+    ],
+    "styleFiles": [
+      "localhost:3030/sapling-dev-server/oauth-login/static/css/oauth-login.css"
+    ],
+    "workerFiles": []
+  }
+]

--- a/saplings/oauth-login/src/index.js
+++ b/saplings/oauth-login/src/index.js
@@ -24,8 +24,8 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 
-registerConfigSapling('oauth-login', () => {
-  if (window.location.pathname === '/oauth-login') {
+registerConfigSapling('login', () => {
+  if (window.location.pathname === '/login') {
     hideCanopy();
     registerApp(domNode => {
       ReactDOM.render(<App />, domNode);


### PR DESCRIPTION
Separates the configs and dockerfiles into Biome- and OAuth-specific variants. This allows the UI to be run with either auth type.

To test:
1. Run `docker-compose -f docker-compose-biome.yaml up --build` from the repo root
2. Navigate to `localhost:3030` in your browser and verify that the login form appears (asks for username and password)
3. Run `docker-compose -f docker-compose-biome.yaml down` to cleanup
1. Run `docker-compose -f docker-compose-oauth.yaml up --build` from the repo root
2. Navigate to `localhost:3030` in your browser and verify that the OAuth login button appears
3. Run `docker-compose -f docker-compose-oauth.yaml down` to cleanup