### PR TITLE
Link OAuth login button to login endpoint

### DIFF
--- a/saplings/oauth-login/package.json
+++ b/saplings/oauth-login/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-toast-notifications": "^2.4.0",
     "splinter-saplingjs": "github:cargill/splinter-saplingjs#master"
   },
   "devDependencies": {

--- a/saplings/oauth-login/package.json
+++ b/saplings/oauth-login/package.json
@@ -31,6 +31,7 @@
     ]
   },
   "dependencies": {
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-toast-notifications": "^2.4.0",

--- a/saplings/oauth-login/src/App.js
+++ b/saplings/oauth-login/src/App.js
@@ -15,19 +15,28 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { ToastProvider } from 'react-toast-notifications';
 import './App.css';
 
 import { OAuthLoginButton } from './components/OAuthLoginButton';
 
-function App() {
+function App({ errorMessage }) {
   return (
     <div className="oauth-login-app">
       <ToastProvider>
-        <OAuthLoginButton />
+        <OAuthLoginButton errorMessage={errorMessage} />
       </ToastProvider>
     </div>
   );
 }
+
+App.propTypes = {
+  errorMessage: PropTypes.string
+};
+
+App.defaultProps = {
+  errorMessage: null
+};
 
 export default App;

--- a/saplings/oauth-login/src/App.js
+++ b/saplings/oauth-login/src/App.js
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { ToastProvider } from 'react-toast-notifications';
 import './App.css';
 
 import { OAuthLoginButton } from './components/OAuthLoginButton';
@@ -22,7 +23,9 @@ import { OAuthLoginButton } from './components/OAuthLoginButton';
 function App() {
   return (
     <div className="oauth-login-app">
-      <OAuthLoginButton />
+      <ToastProvider>
+        <OAuthLoginButton />
+      </ToastProvider>
     </div>
   );
 }

--- a/saplings/oauth-login/src/components/OAuthLoginButton.js
+++ b/saplings/oauth-login/src/components/OAuthLoginButton.js
@@ -16,13 +16,17 @@
 
 import React from 'react';
 import { useToasts } from 'react-toast-notifications';
+import PropTypes from 'prop-types';
 import './OAuthLoginButton.scss';
 import { getSharedConfig } from 'splinter-saplingjs';
 
 const { splinterURL } = getSharedConfig().canopyConfig;
 
-export function OAuthLoginButton() {
+export function OAuthLoginButton({ errorMessage }) {
   const { addToast } = useToasts();
+  if (errorMessage) {
+    addToast(`${errorMessage}`, { appearance: 'error' });
+  }
 
   const AuthUrlResponse = async () => {
     try {
@@ -53,3 +57,11 @@ export function OAuthLoginButton() {
     </div>
   );
 }
+
+OAuthLoginButton.propTypes = {
+  errorMessage: PropTypes.string
+};
+
+OAuthLoginButton.defaultProps = {
+  errorMessage: null
+};

--- a/saplings/oauth-login/src/components/OAuthLoginButton.js
+++ b/saplings/oauth-login/src/components/OAuthLoginButton.js
@@ -15,16 +15,38 @@
  */
 
 import React from 'react';
+import { useToasts } from 'react-toast-notifications';
 import './OAuthLoginButton.scss';
+import { getSharedConfig } from 'splinter-saplingjs';
+
+const { splinterURL } = getSharedConfig().canopyConfig;
 
 export function OAuthLoginButton() {
+  const { addToast } = useToasts();
+
+  const AuthUrlResponse = async () => {
+    try {
+      window.location.replace(
+        `${splinterURL}/oauth/login?redirect_url=${window.location.href}`
+      );
+    } catch (e) {
+      addToast(`Unable to redirect to OAuth login`, { appearance: 'error' });
+    }
+  };
+
   return (
     <div className="oauth-login-button-wrapper">
       <div className="btn-header">
         <div className="btn-title">Log In</div>
       </div>
       <div className="btn-wrapper">
-        <button type="button" className="button btn log-in">
+        <button
+          type="button"
+          className="button btn log-in"
+          onClick={() => {
+            AuthUrlResponse();
+          }}
+        >
           Log in using OAuth2.0
         </button>
       </div>


### PR DESCRIPTION
Sets the OAuth login sapling's button to direct the user to the Splinter daemon's OAuth login endpoint. Also handles the access token and the user ID returned by the `oauth/callback` endpoint.