### PR TITLE
Display error message inside div element

### DIFF
--- a/saplings/oauth-login/src/components/OAuthLoginButton.js
+++ b/saplings/oauth-login/src/components/OAuthLoginButton.js
@@ -24,9 +24,6 @@ const { splinterURL } = getSharedConfig().canopyConfig;
 
 export function OAuthLoginButton({ errorMessage }) {
   const { addToast } = useToasts();
-  if (errorMessage) {
-    addToast(`${errorMessage}`, { appearance: 'error' });
-  }
 
   const AuthUrlResponse = async () => {
     try {
@@ -42,6 +39,7 @@ export function OAuthLoginButton({ errorMessage }) {
     <div className="oauth-login-button-wrapper">
       <div className="btn-header">
         <div className="btn-title">Log In</div>
+        <div className="login-err">{errorMessage}</div>
       </div>
       <div className="btn-wrapper">
         <button

--- a/saplings/oauth-login/src/components/OAuthLoginButton.scss
+++ b/saplings/oauth-login/src/components/OAuthLoginButton.scss
@@ -31,6 +31,12 @@
       display: flex;
       justify-content: center;
     }
+
+    .login-err {
+      color: var(--color-attention);
+      display: flex;
+      justify-content: center;
+    }
   }
 
   .btn-wrapper {


### PR DESCRIPTION
Moves the error message, if encountered, to be displayed within a div element above the log-in button, rather than in a toast notification.