### PR TITLE
Fix `display_name` and `user_id` regexes

### DIFF
--- a/saplings/oauth-login/src/index.js
+++ b/saplings/oauth-login/src/index.js
@@ -31,15 +31,15 @@ registerConfigSapling('login', () => {
     window.$CANOPY.redirectedFrom.includes('access_token')
   ) {
     // Extract user token information
-    const accessTokenRegex = /\?access_token=([^&#]*)|&|$/;
+    const accessTokenRegex = /[?|&]access_token=([^&#]*)|&|$/;
     const token = window.$CANOPY.redirectedFrom.match(accessTokenRegex)[1];
     // Extract user information
-    const userIdRegex = /\?user_id=([^&#]*)|&|$/;
+    const userIdRegex = /[?|&]user_id=([^&#]*)|&|$/;
     let userId = window.$CANOPY.redirectedFrom.match(userIdRegex)[1];
     if (!userId) {
       userId = 'OAuthUser';
     }
-    const displayNameRegex = /\?display_name=([^&#]*)|&|$/;
+    const displayNameRegex = /[?|&]display_name=([^&#]*)|&|$/;
     let displayName = window.$CANOPY.redirectedFrom.match(displayNameRegex)[1];
     if (!displayName) {
       displayName = 'OAuthUser';


### PR DESCRIPTION
Fixes the regexes used to extract the `display_name` and the `user_id`
from the redirect URL used once authentication has completed.
Previously, the character used at the beginning of these regexes was a
`?`, where it should have been `&` to collect query parameters.

To test: Checkout this test branch: https://github.com/shannynalayna/splinter-ui/tree/test-fix-regex, which has this commit as well as the necessary docker-compose set - up to use Splinter locally. A test Splinter branch can be checked out here: https://github.com/shannynalayna/splinter/tree/shannynalayna-local-setup. Run `docker-compose -f docker-compose-oauth.yaml up --build` from the UI top-level directory