### PR TITLE
Add function to logout an OAuth user

### DIFF
--- a/saplings/oauth-login/src/index.js
+++ b/saplings/oauth-login/src/index.js
@@ -50,6 +50,8 @@ registerConfigSapling('login', () => {
       userId,
       displayName
     });
+    // Set the OAuth logout route
+    sessionStorage.setItem('LOGOUT', '/oauth/logout');
 
     window.$CANOPY.redirectedFrom = window.location.href;
     window.location.replace('/');

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -170,11 +170,36 @@ export function Profile() {
     setModalActive(false);
   };
 
-  const logout = () => {
+  const logout = async () => {
     sessionStorage.removeItem('CANOPY_USER');
     sessionStorage.removeItem('CANOPY_KEYS');
     sessionStorage.removeItem('KEY_SECRET');
-    window.location.href = `${window.location.origin}/login`;
+
+    if (sessionStorage.getItem('LOGOUT')) {
+      try {
+        const { splinterURL } = getSharedConfig().canopyConfig;
+        await http(
+          'GET',
+          `${splinterURL}${sessionStorage.getItem('LOGOUT')}`,
+          {},
+          request => {
+            request.setRequestHeader('Authorization', `Bearer ${user.token}`);
+          }
+        );
+        sessionStorage.removeItem('LOGOUT');
+        window.location.href = `${window.location.origin}/login`;
+      } catch (err) {
+        switch (err.code) {
+          case '401':
+            window.location.href = `${window.location.origin}/login`;
+            break;
+          default:
+            break;
+        }
+      }
+    } else {
+      window.location.href = `${window.location.origin}/login`;
+    }
   };
 
   return (


### PR DESCRIPTION
Adds a line to the OAuth login Sapling to set a local session storage
value to Splinter REST API's `/oauth/logout` endpoint. Also adds a
function to the Profile Sapling to check if this value has been set, and
if so, makes a request to the logout endpoint with the correct
authorization headers.

Actually testing the logout functionality is mildly dependent upon this PR: https://github.com/Cargill/splinter/pull/1043, so might need to check out that PR to use as your Splinter image. There is a commit accompanied with the commit in this PR in this branch: https://github.com/shannynalayna/splinter-ui/tree/shannynalayna-test-logout, that can be used to test the functionality of this PR & of Splinter PR 1043. Run `docker-compose up --build` from the base directory and navigate to `localhost:3030` once everything is built. You should be able to log in / log out and see the `/oauth/logout` request receive a 200 response from the Splinter REST API. 