### PR TITLE
Add environment variables to OAuth docker-compose

### DIFF
--- a/docker-compose-oauth.yaml
+++ b/docker-compose-oauth.yaml
@@ -60,6 +60,13 @@ services:
         --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
         --tls-insecure
       "
+    environment:
+      - OAUTH_REDIRECT_URL=http://localhost:3030/splinterd/oauth/callback
+      - OAUTH_PROVIDER
+      - OAUTH_CLIENT_ID
+      - OAUTH_CLIENT_SECRET
+      - OAUTH_OPENID_URL
+
   splinter-db-alpha:
     image: postgres
     container_name: splinter-db-alpha
@@ -124,6 +131,13 @@ services:
         --database postgres://admin:admin@splinter-db-beta:5432/splinter \
         --tls-insecure
       "
+    environment:
+      - OAUTH_REDIRECT_URL=http://localhost:3031/splinterd/oauth/callback
+      - OAUTH_PROVIDER
+      - OAUTH_CLIENT_ID
+      - OAUTH_CLIENT_SECRET
+      - OAUTH_OPENID_URL
+
   splinter-db-beta:
     image: postgres
     container_name: splinter-db-beta


### PR DESCRIPTION
This change adds the OAuth environment variables to the docker-compose-oauth file.  This allows splinterd to be configured for OAuth-based authorization.
