### PR TITLE
Modify displayName format

### DIFF
--- a/saplings/oauth-login/src/index.js
+++ b/saplings/oauth-login/src/index.js
@@ -48,7 +48,7 @@ registerConfigSapling('login', () => {
     setUser({
       token,
       userId,
-      displayName
+      displayName: decodeURI(displayName)
     });
     // Set the OAuth logout route
     sessionStorage.setItem('LOGOUT', '/oauth/logout');


### PR DESCRIPTION
url decode `displayName` in the oauth-login sapling. This change is necessary for the situation where the account used for
logging in to splinter admin ui exists but does not have an associated email address. In this case the value of `displayName`
will be the user's `name` which could contain spaces.