### PR TITLE
Add circuit display name to the Circuits Sapling

### DIFF
--- a/docker-compose-biome.yaml
+++ b/docker-compose-biome.yaml
@@ -24,7 +24,7 @@ services:
   # ---== alpha node ==---
 
   splinterd-alpha:
-    image: splintercommunity/splinterd:experimental
+    image: splintercommunity/splinterd:master
     container_name: splinterd-alpha
     hostname: splinterd-alpha
     expose:
@@ -89,7 +89,7 @@ services:
 # ---== beta node ==---
 
   splinterd-beta:
-    image: splintercommunity/splinterd:experimental
+    image: splintercommunity/splinterd:master
     container_name: splinterd-beta
     hostname: splinterd-beta
     expose:

--- a/docker-compose-oauth.yaml
+++ b/docker-compose-oauth.yaml
@@ -46,7 +46,7 @@ services:
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoints tcps://splinterd-alpha:8044 \
         --node-id alpha-node-000 \
@@ -117,7 +117,7 @@ services:
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoints tcps://splinterd-beta:8044 \
         --node-id beta-node-000 \

--- a/saplings/circuits/protos/admin.proto
+++ b/saplings/circuits/protos/admin.proto
@@ -95,6 +95,9 @@ message Circuit {
 
     // Human-readable comments about the circuit
     string comments = 10;
+
+    // Human-readable display name of the circuit
+    string display_name = 11;
 }
 
 // Contains the vote counts for a given proposal.

--- a/saplings/circuits/src/components/ProposalReview.js
+++ b/saplings/circuits/src/components/ProposalReview.js
@@ -32,7 +32,8 @@ const ProposalReview = ({
   services,
   managementType,
   comments,
-  metadata
+  metadata,
+  displayName
 }) => {
   const localNodeID = useLocalNodeState();
   return (
@@ -58,6 +59,8 @@ const ProposalReview = ({
       </div>
       <div className="details-container">
         <div className="title">Details</div>
+        <div className="label">Display Name</div>
+        <div className="field-value">{displayName}</div>
         <div className="label">Management type</div>
         <div className="field-value">{managementType}</div>
         <div className="label">Comments</div>
@@ -87,7 +90,8 @@ ProposalReview.propTypes = {
   metadata: PropTypes.shape({
     metadata: PropTypes.string,
     encoding: PropTypes.string
-  }).isRequired
+  }).isRequired,
+  displayName: PropTypes.string.isRequired
 };
 
 ProposalReview.defaultProps = {};

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
@@ -82,6 +82,35 @@ const CircuitDetails = () => {
     }
   }, [circuit, user]);
 
+  const getCircuitTitle = () => {
+    if (circuit.displayName) {
+      return (
+        <div className="circuit-title">
+          <h4>{`${circuit.displayName}`}</h4>
+          <h6>{`Circuit ${circuitId}`}</h6>
+          <div className="managementType">
+            {circuit.managementType}
+            <span>
+              <FontAwesomeIcon icon={faQuestionCircle} />
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="circuit-title">
+        <h4>{`Circuit ${circuitId}`}</h4>
+        <div className="managementType">
+          {circuit.managementType}
+          <span>
+            <FontAwesomeIcon icon={faQuestionCircle} />
+          </span>
+        </div>
+      </div>
+    );
+  };
+
   if (!circuit) {
     return <div />;
   }
@@ -108,15 +137,7 @@ const CircuitDetails = () => {
           </div>
           {requiresAction}
           <div className="mid-header-wrapper">
-            <div className="circuit-title">
-              <h4>{`Circuit ${circuitId}`}</h4>
-              <div className="managementType">
-                {circuit.managementType}
-                <span>
-                  <FontAwesomeIcon icon={faQuestionCircle} />
-                </span>
-              </div>
-            </div>
+            {getCircuitTitle()}
             {circuit.actionRequired(localNodeID) && (
               <VoteButton
                 onClickFn={() => {

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
@@ -55,6 +55,10 @@
     flex: 1;
 
     h4 {
+      font-weight: 100;
+      margin: 0 1rem 0 0;
+    }
+    h6 {
       color: var(--color-grey);
       font-weight: 100;
       margin: 0 1rem 0 0;

--- a/saplings/circuits/src/components/circuitsTable/Table.js
+++ b/saplings/circuits/src/components/circuitsTable/Table.js
@@ -25,7 +25,7 @@ import './CircuitsTable.scss';
 const CircuitsTable = ({ circuits, dispatch }) => {
   let rows = (
     <tr key="empty">
-      <td colSpan="5" className="no-circuits-msg">
+      <td colSpan="6" className="no-circuits-msg">
         No circuits found
       </td>
     </tr>

--- a/saplings/circuits/src/components/circuitsTable/TableHeader.js
+++ b/saplings/circuits/src/components/circuitsTable/TableHeader.js
@@ -193,6 +193,14 @@ const TableHeader = ({ dispatch, circuits }) => {
     <thead>
       <tr className="table-header">
         <th
+          onClick={() => {
+            sortCircuitsBy('displayName', !sortedBy.ascendingOrder);
+          }}
+        >
+          Circuit Name
+          {sortSymbol('displayName')}
+        </th>
+        <th
           onClick={() => sortCircuitsBy('circuitID', !sortedBy.ascendingOrder)}
         >
           Circuit ID

--- a/saplings/circuits/src/components/circuitsTable/TableRow.js
+++ b/saplings/circuits/src/components/circuitsTable/TableRow.js
@@ -88,6 +88,9 @@ const TableRow = ({ circuit }) => {
         history.push(`/circuits/${circuit.id}`);
       }}
     >
+      <td className={circuit.displayName === '' ? 'text-grey' : ''}>
+        <div>{circuit.displayName}</div>
+      </td>
       <td className="text-highlight">{circuit.id}</td>
       <td>{members()}</td>
       <td>{serviceTypeCount()}</td>

--- a/saplings/circuits/src/components/forms/propose_circuit/index.js
+++ b/saplings/circuits/src/components/forms/propose_circuit/index.js
@@ -233,6 +233,12 @@ const servicesReducer = (state, [action, ...args]) => {
 
 const detailsReducer = (state, action) => {
   switch (action.type) {
+    case 'set-display-name': {
+      const { displayName } = action;
+      const newState = state;
+      newState.displayName = displayName;
+      return { ...newState };
+    }
     case 'set-management-type': {
       const { managementType } = action;
       const newState = state;
@@ -345,6 +351,7 @@ export function ProposeCircuitForm() {
   const [detailsState, detailsDispatcher] = useReducer(detailsReducer, {
     managementType: '',
     comments: '',
+    displayName: '',
     errors: {
       managementType: ''
     }
@@ -413,7 +420,8 @@ export function ProposeCircuitForm() {
       routes: protos.Circuit.RouteType.ANY_ROUTE,
       circuitManagementType: detailsState.managementType,
       applicationMetadata: metadata,
-      comments: detailsState.comments
+      comments: detailsState.comments,
+      displayName: detailsState.displayName
     });
     const circuitCreateRequest = protos.CircuitCreateRequest.create({
       circuit
@@ -676,6 +684,20 @@ export function ProposeCircuitForm() {
         </div>
         <div className="propose-form-wrapper circuit-details-wrapper">
           <div className="input-wrapper">
+            <div className="label">Display name</div>
+            <input
+              type="text"
+              className="form-input"
+              value={detailsState.displayName}
+              onChange={e => {
+                detailsDispatcher({
+                  type: 'set-display-name',
+                  displayName: e.target.value
+                });
+              }}
+            />
+          </div>
+          <div className="input-wrapper">
             <div className="label">Management type</div>
             <input
               type="text"
@@ -768,6 +790,7 @@ export function ProposeCircuitForm() {
               encoding: metadataState.encoding,
               metadata: metadataState.metadata
             }}
+            displayName={detailsState.displayName}
           />
         </div>
       </Step>

--- a/saplings/circuits/src/components/forms/propose_circuit/index.scss
+++ b/saplings/circuits/src/components/forms/propose_circuit/index.scss
@@ -220,9 +220,12 @@
   }
 }
 
-.textarea-wrapper {
-  height: 70%;
+.circuit-details-wrapper {
+  margin: 0;
+  padding: 0;
+}
 
+.textarea-wrapper {
   .form-textarea {
     max-height: 70%;
     resize: vertical;

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -93,6 +93,9 @@ function Circuit(data) {
     );
     this.encodedApplicationData = data.circuit.application_metadata;
     this.comments = data.circuit.comments;
+    if (data.circuit.display_name) {
+      this.displayName = data.circuit.display_name;
+    }
     this.proposal = {
       votes: data.votes,
       requester: data.requester,
@@ -109,6 +112,9 @@ function Circuit(data) {
     this.applicationMetadata = metadataFromJson(data.application_metadata);
     this.encodedApplicationData = data.application_metadata;
     this.comments = 'N/A';
+    if (data.display_name) {
+      this.displayName = data.display_name;
+    }
     this.proposal = {
       votes: [],
       requester: '',

--- a/saplings/circuits/src/data/circuits.js
+++ b/saplings/circuits/src/data/circuits.js
@@ -66,7 +66,11 @@ function Service(jsonSource) {
   if (jsonSource) {
     this.serviceId = jsonSource.service_id;
     this.serviceType = jsonSource.service_type;
-    this.allowedNodes = jsonSource.allowed_nodes;
+    if (jsonSource.node_id) {
+      this.allowedNodes = [jsonSource.node_id];
+    } else {
+      this.allowedNodes = jsonSource.allowed_nodes;
+    }
     this.arguments = argsToObject(jsonSource.arguments);
   } else {
     this.serviceId = '';

--- a/saplings/circuits/src/state/circuits.js
+++ b/saplings/circuits/src/state/circuits.js
@@ -30,6 +30,9 @@ const REFREST_INTERVAL = 10000; // ten seconds;
 const filterCircuitsByTerm = filterBy => {
   if (filterBy.filterTerm.length > 0) {
     return circuit => {
+      if (circuit.displayName.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
+        return true;
+      }
       if (circuit.id.toLowerCase().indexOf(filterBy.filterTerm) > -1) {
         return true;
       }
@@ -93,6 +96,23 @@ const sortCircuits = ({ field, ascendingOrder }) => {
           return order;
         }
         if (circuitA.comments > circuitB.comments) {
+          return -order;
+        }
+        return 0;
+      };
+    }
+    case 'displayName': {
+      return (circuitA, circuitB) => {
+        if (!circuitA.displayName && circuitB.displayName) {
+          return 1; // 'Empty display names should always be at the bottom'
+        }
+        if (circuitA.displayName && !circuitB.displayName) {
+          return -1; // 'Empty display names should always be at the bottom'
+        }
+        if (circuitA.displayName < circuitB.displayName) {
+          return order;
+        }
+        if (circuitA.displayName > circuitB.displayName) {
           return -order;
         }
         return 0;


### PR DESCRIPTION
Adds the circuit display name throughout the Circuits Sapling. Including displaying this value, if set, and adding a field for this value in the form to propose a circuit. 

Can be tested by running `docker-compose -f docker-compose-biome.yaml up`. 

You can access the keys registered to the nodes in this docker-compose file by running `docker-compose -f docker-compose-biome.yaml run generate-registry bash`, and then accessing the keys in the /registry directory within that container. 

Then, go to `localhost:3030`, log in, activate the key within the Profile sapling, and go to the circuits sapling from the left nav bar. You should be able to see the `display name` column within this table, even if no circuits/proposals have been submitted. Note, this PR also updates the CircuitsDetails page, so if a circuit is created and you select it from the table referenced earlier, you should be brought to a circuit details page, which also shows the circuit's display name, if it is set. 

This PR also includes some small updates required by updates to Splinter.