### PR TITLE
Update error handling in Circuits sapling

### DIFF
--- a/saplings/circuits/src/api/splinter.js
+++ b/saplings/circuits/src/api/splinter.js
@@ -30,7 +30,7 @@ export const getNodeID = async token => {
   if (result.ok) {
     return result.json.node_id;
   }
-  throw Error(result.data);
+  throw Error(result.json.message);
 };
 
 export const listProposals = async token => {
@@ -42,7 +42,7 @@ export const listProposals = async token => {
   if (result.ok) {
     return result.json;
   }
-  throw Error(result.data);
+  throw Error(result.json.message);
 };
 
 export const getProposal = async (circuitId, token) => {
@@ -54,7 +54,7 @@ export const getProposal = async (circuitId, token) => {
   if (result.ok) {
     return result.json;
   }
-  throw Error(result.data);
+  throw Error(result.json.message);
 };
 
 export const listCircuits = async token => {
@@ -66,7 +66,7 @@ export const listCircuits = async token => {
   if (result.ok) {
     return result.json;
   }
-  throw Error(result.data);
+  throw Error(result.json.message);
 };
 
 export const getCircuit = async (circuitId, token) => {
@@ -78,7 +78,7 @@ export const getCircuit = async (circuitId, token) => {
   if (result.ok) {
     return result.json;
   }
-  throw Error(result.data);
+  throw Error(result.json.message);
 };
 
 export const getNodeRegistry = async token => {
@@ -91,7 +91,7 @@ export const getNodeRegistry = async token => {
     const response = new NodeRegistryResponse(result.json);
     return response.data;
   }
-  throw Error(result.data);
+  throw Error(result.json.message);
 };
 
 export const postNode = async (node, token) => {

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.scss
@@ -179,3 +179,13 @@
     }
   }
 }
+
+.error-message {
+  display: inline-flex;
+  h4 {
+    color: var(--color-attention);
+    padding: 5rem;
+    font-size: 26px;
+    font-weight: 100;
+  }
+}

--- a/saplings/circuits/src/components/forms/NewNodeForm.js
+++ b/saplings/circuits/src/components/forms/NewNodeForm.js
@@ -417,7 +417,7 @@ export function NewNodeForm({ closeFn, successCallback }) {
       successCallback(new Node(node));
       addToast('Node submitted successfully', { appearance: 'success' });
     } catch (e) {
-      addToast(`${e}`, { appearance: 'error' });
+      addToast(`${e.json.message}`, { appearance: 'error' });
     }
   };
 

--- a/saplings/circuits/src/components/forms/VoteOnProposalForm.js
+++ b/saplings/circuits/src/components/forms/VoteOnProposalForm.js
@@ -82,7 +82,7 @@ const VoteOnProposalForm = ({ proposal, nodes, closeFn }) => {
         history.push(`/circuits`);
       }
     } catch (e) {
-      addToast(`${e}`, { appearance: 'error' });
+      addToast(`${e.json.message}`, { appearance: 'error' });
     }
   };
 

--- a/saplings/circuits/src/state/localNode.js
+++ b/saplings/circuits/src/state/localNode.js
@@ -32,7 +32,7 @@ function LocalNodeProvider({ children }) {
           const node = await getNodeID(user.token);
           setNodeID({ nodeID: node });
         } catch (e) {
-          throw Error(`Error fetching node information: ${e}`);
+          throw Error(`Error fetching node information: ${e.json.message}`);
         }
       }
     };

--- a/saplings/circuits/src/state/nodeRegistry.js
+++ b/saplings/circuits/src/state/nodeRegistry.js
@@ -29,7 +29,9 @@ function useNodeRegistryState() {
           const nodes = await getNodeRegistry(user.token);
           setNodes({ nodes });
         } catch (e) {
-          throw Error(`Error fetching information from node registry: ${e}`);
+          throw Error(
+            `Error fetching information from node registry: ${e.json.message}`
+          );
         }
       }
     };


### PR DESCRIPTION
Updates some current error messages to pull out the error message, rather
than the entire error object, which did not render in the UI as a
human-readable error message.

Also updates the `getCircuit` function to redirect to the Circuits
sapling base page if an error is encountered fetching a circuit from
the splinter daemon, rather than continue with null data which led to
odd behavior in the UI that didn't make it clear an error had been
encountered.

Testing: Run the admin UI with the `oauth` docker-compose file, then go to the admin UI and see the behavior in the Circuits sapliing when the client is unauthorized. After logging in, you should also be able to go to `localhost:3030/circuits/12345-abcde` (which triggers the CircuitDetails part of the sapling, which attempts to fetch the circuit/proposal from splinterd) and see the redirect that now happens when the client is not authorized to view the circuit. If a key is associated with the UI account, you should also be able to go partially through the circuit proposal form and see the toast notification when submitting data that should state that the client is not authorized. Before this update, the toast errors did not render correctly in the UI.
Note: The full functionality of the Circuits sapling is blocked by the UI not being able to communicate with the splinter daemon, as it is unauthorized. 