### PR TITLE
Update admin ui for new canopy left nav

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -20,6 +20,7 @@ limitations under the License.
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="UI for Splinter" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <title>Splinter</title>
 </head>
 

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -15,16 +15,11 @@
  */
 
 import React from 'react';
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { faLeaf, faUserCircle } from '@fortawesome/free-solid-svg-icons';
 import { CanopyProvider, SideNav } from 'splinter-canopyjs';
 
 import './App.scss';
 
 window.$CANOPY = {};
-
-library.add(faLeaf);
-library.add(faUserCircle);
 
 function AppWithProvider() {
   return (

--- a/app/src/theme/colors.scss
+++ b/app/src/theme/colors.scss
@@ -21,6 +21,7 @@ $color-primary-dark: darken($color-primary, 15%) !default;
 $color-secondary: #ff8f6b !default;
 $color-secondary-light: lighten($color-secondary, 15%);
 $color-secondary-dark: darken($color-secondary, 15%);
+$color-brand-background: #EEEEEE;
 
 :root {
   --color-primary: #{$color-primary};
@@ -30,6 +31,7 @@ $color-secondary-dark: darken($color-secondary, 15%);
   --color-secondary: #{$color-secondary};
   --color-secondary-light: #{$color-secondary-light};
   --color-secondary-dark: #{$color-secondary-dark};
+  --color-brand-background: #{$color-brand-background};
   --color-dark-grey: #333333;
   --color-grey: #555555;
   --color-light-grey: #DDDDDD;

--- a/sapling-dev-server/userSaplings
+++ b/sapling-dev-server/userSaplings
@@ -9,6 +9,6 @@
       "localhost:3030/sapling-dev-server/circuits/static/css/circuits.css"
     ],
     "workerFiles": [],
-    "icon": "http://localhost:3030/sapling-dev-server/circuits/images/circuits_logo.svg"
+    "icon": "device_hub_icon"
   }
 ]

--- a/saplings/profile/package.json
+++ b/saplings/profile/package.json
@@ -9,6 +9,8 @@
     "@fortawesome/free-regular-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
+    "@material-ui/core": "^4.11.2",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",


### PR DESCRIPTION
Modify the splinter admin ui for changes made to left nav in `splinter-canopyjs`
- Add the stylesheet for material icons
- Remove unnecessary FA icons
- Add a color-brand-background variable to the stylesheet to be used in the left nav in `splinter-canopyjs`
- Update the sapling-dev-server json file to use the name of a material icon for the circuit tab

## **Testing:**
- run `docker-compose` with either the `docker-compose-oauth` or `docker-compose-biome` docker file
- navigate to `http://localhost:3030`
- register/login to view the updated navigation bar in the splinter admin ui