### PR TITLE
Fix splinter-canopyjs github dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "^3.4.0",
-    "splinter-canopyjs": "github:cargill/splinter-canopyjs#master"
+    "splinter-canopyjs": "github:cargill/splinter-canopyjs#main"
   },
   "devDependencies": {
     "eslint": "^6.6.0",


### PR DESCRIPTION
The splinter-canopyjs master branch was renamed to `main` so this PR updates the splinter-canopyjs github dependency to reflect this change.