### PR TITLE
Implement profile sapling key table

### DIFF
--- a/saplings/profile/src/App.js
+++ b/saplings/profile/src/App.js
@@ -18,14 +18,21 @@ import './App.scss';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { Profile } from './Profile';
 import { NewKey } from './components/NewKey';
+import { SaplingHeader } from './components/SaplingHeader';
 
 function App() {
   return (
     <div className="profile-app">
       <Router>
         <Switch>
-          <Route exact path="/profile" component={Profile}/>
-          <Route exact path="/profile/new-key" component={NewKey}/>
+          <Route exact path="/profile">
+            <SaplingHeader saplingName="Profile"/>
+            <Profile />
+          </Route>
+          <Route exact path="/profile/new-key">
+            <SaplingHeader saplingName="Profile"/>
+            <NewKey />
+          </Route>
         </Switch>
       </Router>
     </div>

--- a/saplings/profile/src/App.js
+++ b/saplings/profile/src/App.js
@@ -18,7 +18,7 @@ import './App.scss';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { Profile } from './Profile';
 import { NewKey } from './components/NewKey';
-import { SaplingHeader } from './components/SaplingHeader';
+import SaplingHeader from './components/SaplingHeader';
 
 function App() {
   return (

--- a/saplings/profile/src/App.scss
+++ b/saplings/profile/src/App.scss
@@ -17,4 +17,5 @@
 .profile-app {
   display: flex;
   flex-direction: column;
+  background: #EEEEEE;
 }

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -25,11 +25,6 @@ export function Profile() {
 
   return (
     <div id="profile">
-      <section className="sapling-header">
-        <div className="sapling-name">
-            Profile
-        </div>
-      </section>
       <section className="profile-info">
         <div className="profile-photo">
           <div className="icon">

--- a/saplings/profile/src/Profile.scss
+++ b/saplings/profile/src/Profile.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 Cargill Incorporated
+ * Copyright 2018-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/saplings/profile/src/Profile.scss
+++ b/saplings/profile/src/Profile.scss
@@ -15,9 +15,8 @@
  */
 
 #profile {
-  background: #EEEEEE;
   position: relative;
-  height: 1440px;
+  height: 100%;
   display: flex;
   flex-direction: column;
 
@@ -38,7 +37,7 @@
       justify-content: center;
       align-items: center;
       display: flex;
-      margin: 20px;
+      margin: 2% 2% 0% 0%;
 
       .icon {
         height: 102px;
@@ -67,37 +66,145 @@
         color: #7A7A7A;
       }
     }
+
+    .action-list {
+      .actions.open {
+        background: #ffffff;
+      }
+    }
   }
 
-    button {
-      border: none;
-      color: #ffffff;
-      background: var(--color-primary);
-      padding: 4px 16px;
-      border-radius: 3px;
-      align-items: center;
+  .action-list {
+    position: absolute;
+    top: 1rem;
+    right: 0.25rem;
+  }
+
+  #user-key-table {
+    flex: 0 1 100%;
+    width: 100%;
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+
+    .keys-header {
       display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0rem 1.5rem;
 
-      &.flat {
-        background: var(--color-primary-dark);
-        color: #555555;
-        border: 1px solid #555555;
-        transition: all 0.2s;
-
-        &:hover {
-          background: var(--color-primary-dark);
-          color: #ffffff;
-        }
+      #keys-label {
+        font-family: Helvetica Neue;
+        font-style: normal;
+        font-weight: normal;
+        color: #595C60;
+        display: inline-block;
+        font-size: 36px;
       }
+    }
 
-      &.fab {
-        border-radius: 50%;
-        background: var(--color-secondary);
-        color: #333333;
-      }
+    .keys-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-direction: row;
+      padding: 0% 2%;
+    }
+  }
+
+  .info-field {
+    align-self: center;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: 1fr;
+    grid-template-areas: 'info actions';
+    width: fit-content;
+
+    .label {
+      width: fit-content;
+      color: var(--color-text-light--on-dark);
+    }
+
+    .value {
+      width: fit-content;
+      margin: 0;
+    }
+
+    .field-action {
+      margin: 0 2rem;
+      align-self: center;
+      justify-self: flex-start;
+    }
+  }
+
+  button {
+    border: none;
+    color: #ffffff;
+    background: #555555;
+    padding: 1rem;
+
+    &.flat {
+      background: transparent;
+      color: #555555;
+      border: 1px solid #555555;
+      transition: all 0.2s;
 
       &:hover {
         cursor: pointer;
+        background: #555555;
+        color: #ffffff;
       }
     }
+
+    &.fab {
+      border-radius: 50%;
+      background: var(--color-secondary);
+      color: #333333;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  form {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 1rem;
+
+    button.submit {
+      margin: 1rem 0 0;
+      position: relative;
+      left: 100%;
+      transform: translateX(-100%);
+    }
+  }
+
+  .form-wrapper {
+    display: flex;
+    flex-direction: column;
+
+    .error {
+      border: 1px solid var(--color-failure);
+      padding: 1rem;
+      margin: 1rem 0;
+      color: var(--color-failure);
+    }
+  }
+
+  button.submit {
+    background: var(--color-secondary);
+    color: #333333;
+
+    &:disabled {
+      background: var(--color-grey);
+      color: #ffffff;
+    }
+  }
+
+  button.danger {
+    background: var(--color-failure);
+    color: #333333;
+  }
 }

--- a/saplings/profile/src/Profile.scss
+++ b/saplings/profile/src/Profile.scss
@@ -21,27 +21,6 @@
   display: flex;
   flex-direction: column;
 
-  .sapling-header {
-    background: #ffffff;
-    position: relative;
-    display: flex;
-    padding: 1.5rem;
-    height: 56px;
-    box-sizing: border-box;
-    box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.14), 0px 1px 12px rgba(0, 0, 0, 0.12), 0px 2px 6px rgba(0, 0, 0, 0.1);
-    justify-content: flex-start;
-    align-items: flex-end;
-
-    .sapling-name {
-      font-family: Arial;
-      font-style: normal;
-      font-weight: bold;
-      font-size: 24px;
-      color: #595C60;
-      align-self: center;
-    }
-  }
-
   .profile-info {
     box-sizing: content-box;
     position: relative;

--- a/saplings/profile/src/components/KeyTable.js
+++ b/saplings/profile/src/components/KeyTable.js
@@ -1,70 +1,89 @@
 import React from 'react';
 import './KeyTable.scss';
-import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import Icon from '@material-ui/core/Icon';
 import KeyTableNav from './KeyTableNav';
 
+const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
+
+  const emptyRows = [];
+  const rows = keys.map(key => {
+    const isActive = activeKey === key.public_key;
+    return (
+      <tr key={key.public_key}>
+        <td>
+          <div>{key.display_name}</div>
+        </td>
+        <td>
+          <div>{key.public_key}</div>
+        </td>
+        <td />
+        <td />
+        <td>{isActive && <div className="status-active">Active</div>}</td>
+        <td>
+          <div className="button-wrapper">
+            <button id="action-button">
+              <Icon>more_horiz_icon</Icon>
+              <span className={`action-options ${isActive ? 'active' : ''}`}>
+              {!isActive &&
+                <button
+                  className="key-action-btn"
+                  onClick={e => {
+                    e.preventDefault();
+                    onActivate(key);
+                  }}
+                >
+                <Icon>check_circle_icon</Icon>
+                </button>}
+                <button
+                  className="key-action-btn"
+                  onClick={e => {
+                      e.preventDefault();
+                      onEdit(key);
+                    }}
+                  >
+                  <Icon>edit_icon</Icon>
+                </button>
+                <button className="key-action-btn">
+                  <Icon>delete_icon</Icon>
+                </button>
+              </span>
+            </button>
           </div>
-          <Link className="add-key" to="/profile/new-key">
-            <div className="icon"><Icon>add_icon</Icon></div>
-            New Key
-          </Link>
-        </div>
-        <div className="table-wrapper">
+        </td>
+      </tr>
+    )
+  })
+  if (keys.length < 10) {
+    for (let i=0; i < 10-keys.length; i+=1) {
+      emptyRows.push(<tr className="empty-row"><td colSpan="6" className="keys-empty" /></tr>)
+    }
+  }
+
+  return (
+    <section className="user-keys">
+      <div className="table-actions">
+        <KeyTableNav totalKeys={keys.length} />
+        <button
+          id="add-key"
+          onClick={onAdd}>
+          <div className="icon"><Icon>add_icon</Icon></div>
+          New Key
+        </button>
+      </div>
+      <div className="table-wrapper">
         <table>
           <thead>
             <tr>
-              <th>Key Name</th>
-              <th>Key</th>
-              <th>Created</th>
-              <th>Updated</th>
-              <th id="status-header">Status</th>
-              <th>Action</th>
+              <th id="key-name-col">Key Name</th>
+              <th id="key-col">Key</th>
+              <th id="created-col">Created</th>
+              <th id="updated-col">Updated</th>
+              <th id="status-col">Status</th>
+              <th id="action-col">Action</th>
             </tr>
           </thead>
-          <tbody>
-            <tr>
-              <td>My Key</td>
-              <td>02be582336357225363b081b9954bf0b0d6539d1def72f09aeaedbda045b9z3c33</td>
-              <td>02/01/2021</td>
-              <td>02/02/2021</td>
-              <td><div className="status-active">Active</div></td>
-              <td><div className="button-wrapper">
-                <button id="action-button">
-                  <Icon>more_horiz_icon</Icon>
-                  <span className="action-options active">
-                    <Icon>edit_icon</Icon>
-                    <Icon>delete_icon</Icon>
-                  </span>
-                </button>
-              </div></td>
-            </tr>
-            <tr>
-              <td>Admin</td>
-              <td>02be582336357225363b081b9954bf0b0d6539d1def72f09aeaedbda045b9z3c33</td>
-              <td>02/01/2021</td>
-              <td>02/02/2021</td>
-              <td />
-              <td><div className="button-wrapper">
-                <button id="action-button">
-                  <Icon>more_horiz_icon</Icon>
-                  <span className="action-options">
-                    <Icon>check_circle_icon</Icon>
-                    <Icon>edit_icon</Icon>
-                    <Icon>delete_icon</Icon>
-                  </span>
-                </button>
-              </div></td>
-            </tr>
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-            <tr className="empty-row" />
-          </tbody>
+          <tbody>{rows}{emptyRows}</tbody>
         </table>
       </div>
       <div className="table-actions">
@@ -72,4 +91,18 @@ import KeyTableNav from './KeyTableNav';
       </div>
     </section>
   );
-}
+};
+
+KeyTable.propTypes = {
+  keys: PropTypes.arrayOf(PropTypes.object).isRequired,
+  activeKey: PropTypes.string,
+  onAdd: PropTypes.func.isRequired,
+  onActivate: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+};
+
+KeyTable.defaultProps = {
+  activeKey: null
+};
+
+export default KeyTable;

--- a/saplings/profile/src/components/KeyTable.js
+++ b/saplings/profile/src/components/KeyTable.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import './KeyTable.scss';
 import PropTypes from 'prop-types';

--- a/saplings/profile/src/components/KeyTable.js
+++ b/saplings/profile/src/components/KeyTable.js
@@ -2,25 +2,8 @@ import React from 'react';
 import './KeyTable.scss';
 import { Link } from 'react-router-dom';
 import Icon from '@material-ui/core/Icon';
+import KeyTableNav from './KeyTableNav';
 
-export function KeyTable() {
-  return (
-      <section className="user-keys">
-        <div className='keys-header'>
-          <h3 id="keys-label">Keys</h3>
-        </div>
-        <div className="table-actions">
-          <div className="table-nav">
-            <div className="total-keys">2 Keys</div>
-            <div className="row-info">
-              <div className="rows-label">Rows per page:</div>
-              <div className="rows-per-page">10</div>
-            </div>
-            <div className="keys-currently-displayed">1-2 of 2</div>
-            <div className="paging">
-              <div className="page-nav"><Icon>keyboard_arrow_left_icon</Icon></div>
-              <div className="page-nav"><Icon>keyboard_arrow_right_icon</Icon></div>
-            </div>
           </div>
           <Link className="add-key" to="/profile/new-key">
             <div className="icon"><Icon>add_icon</Icon></div>
@@ -83,21 +66,10 @@ export function KeyTable() {
             <tr className="empty-row" />
           </tbody>
         </table>
-        </div>
-        <div className="table-actions bottom">
-          <div className="table-nav">
-            <div className="total-keys">2 Keys</div>
-            <div className="row-info">
-              <div className="rows-label">Rows per page:</div>
-              <div className="rows-per-page">10</div>
-            </div>
-            <div className="keys-currently-displayed">1-2 of 2</div>
-            <div className="paging">
-              <div className="page-nav"><Icon>keyboard_arrow_left_icon</Icon></div>
-              <div className="page-nav"><Icon>keyboard_arrow_right_icon</Icon></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      </div>
+      <div className="table-actions">
+        <KeyTableNav totalKeys={keys.length} />
+      </div>
+    </section>
   );
 }

--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -1,17 +1,17 @@
 .user-keys {
-  flex: 0 1 100%;
   align-self: center;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  padding: 1% 2%;
 
   .table-actions {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
     flex-direction: row;
-    padding-bottom: 10px;
+    justify-content: space-between;
+    padding: 1% 0%;
 
-    .add-key {
+    button#add-key {
       border: none;
       color: #ffffff;
       background: var(--color-primary);
@@ -25,6 +25,7 @@
       align-items: center;
       display: flex;
       text-decoration: none;
+      outline: none;
       box-shadow: 0px 2px 6px rgba(0,0,0,.14), 0px 1px 12px rgba(0,0,0,.12), 0px 2px 6px rgba(0,0,0,.1);
 
       .icon {
@@ -45,17 +46,19 @@
 
   .table-wrapper {
     border-radius: 5px 5px 3px 3px;
-    overflow: hidden;
+    overflow-x: scroll;
   }
 
   table {
     border-collapse: collapse;
     width: 100%;
     background: #FFFFFF;
+
     border-radius: 5px 5px 3px 3px;
 
     tr {
       border-bottom: 1px solid #ccd5de;
+      height: 60px;
     }
 
     tr.empty-row {
@@ -68,22 +71,39 @@
       font-weight: bold;
       font-size: 12px;
       color: #545454;
-      padding: 24px 50px;
+      padding: 2%;
       background: #E4E4E4E4;
       text-align: left;
     }
 
-    th#status-header {
-      text-align: center;
+    th#key-name-col {
+      min-width: 108px;
+    }
+
+    th#key-col {
+      min-width: 485px;
+    }
+
+    th#created-col {
+      min-width: 117px;
+    }
+
+    th#updated-col {
+      min-width: 117px;
+    }
+
+    th#status-col {
+      min-width: 88px;
+    }
+
+    th#action-col {
+      min-width: 88px;
     }
 
     td {
       font-size: 12px;
       color: #595C60;
-      text-align: left;
-      padding: 8px;
-      border-bottom: 1px solid #CCD5DE;
-      padding: 11px 50px;
+      padding: 0% 2%;
 
       .status-active {
         background: rgba(79, 189, 120, 0.46);
@@ -96,7 +116,6 @@
       }
 
       .button-wrapper {
-
         button#action-button{
           background: rgba(216, 216, 216, 0.5);
           display: flex;
@@ -122,9 +141,16 @@
             display: flex;
             align-items: center;
             align-self: flex-start;
-            margin-top: 30px;
+            margin-top: 20px;
             flex-direction: row;
             justify-content: space-evenly;
+
+            button.key-action-btn {
+              color: var(--color-primary);
+              background: #EBEBEB;
+              padding: unset;
+              outline: none;
+            }
           }
 
           &:hover {
@@ -140,6 +166,11 @@
           }
         }
       }
+    }
+
+    td.keys-empty {
+      height: 60px;
+      border-bottom: none;
     }
   }
 }

--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .user-keys {
   align-self: center;
   display: flex;

--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -4,80 +4,12 @@
   display: flex;
   flex-direction: column;
 
-  .keys-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-
-    #keys-label {
-      font-family: Helvetica Neue;
-      font-style: normal;
-      font-weight: normal;
-      color: #595C60;
-      display: inline-block;
-      font-size: 36px;
-      width: 9rem;
-      padding-bottom: 0.5rem;
-    }
-  }
-
   .table-actions {
     display: flex;
     align-items: center;
     justify-content: space-between;
     flex-direction: row;
     padding-bottom: 10px;
-
-    .table-nav {
-      flex-direction: row;
-      display: flex;
-      font-style: normal;
-      font-weight: bold;
-      font-size: 14px;
-      align-items: center;
-
-      .total-keys {
-        color: #595C60;
-        padding-right: 20px;
-      }
-
-      .row-info {
-        display: flex;
-        padding-left: 20px;
-        padding-right: 20px;
-
-        .rows-label {
-          color: var(--color-primary);
-          padding-right: 5px;
-        }
-
-        .rows-per-page {
-          color: #595C60;
-        }
-      }
-
-      .keys-currently-displayed {
-        color: #595C60;
-        padding-left: 20px;
-        padding-right: 20px;
-      }
-
-      .paging {
-        display: flex;
-        padding-left: 20px;
-
-        .page-nav {
-          color: var(--color-primary);
-          display: flex;
-          padding: unset;
-          background: none;
-
-          &:hover {
-            color: var(--color-primary-dark)
-          }
-        }
-      }
-    }
 
     .add-key {
       border: none;
@@ -109,9 +41,6 @@
         background: var(--color-primary-dark)
       }
     }
-  }
-  .table-actions.bottom {
-      padding-top: 10px;
   }
 
   .table-wrapper {

--- a/saplings/profile/src/components/KeyTableNav.js
+++ b/saplings/profile/src/components/KeyTableNav.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@material-ui/core/Icon';
+import './KeyTableNav.scss';
+
+const KeyTableNav = ({ totalKeys }) => {
+  return (
+    <div className="table-nav">
+      <div className="total-keys">{totalKeys} Keys</div>
+      <div className="row-info">
+        <div className="rows-label">Rows per page:</div>
+        <div className="rows-per-page">10</div>
+      </div>
+      <div className="keys-currently-displayed">1-{totalKeys} of {totalKeys}</div>
+      <div className="paging">
+        <div className="page-nav"><Icon>keyboard_arrow_left_icon</Icon></div>
+        <div className="page-nav"><Icon>keyboard_arrow_right_icon</Icon></div>
+      </div>
+    </div>
+  );
+};
+
+KeyTableNav.propTypes = {
+  totalKeys: PropTypes.number.isRequired,
+};
+
+export default KeyTableNav;

--- a/saplings/profile/src/components/KeyTableNav.scss
+++ b/saplings/profile/src/components/KeyTableNav.scss
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ .table-nav {
+  flex-direction: row;
+  display: flex;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 14px;
+  align-items: center;
+  align-self: flex-end;
+
+  .total-keys {
+    color: #595C60;
+    padding-right: 20px;
+  }
+
+  .row-info {
+    display: flex;
+    padding-left: 20px;
+    padding-right: 20px;
+
+    .rows-label {
+      color: var(--color-primary);
+      padding-right: 5px;
+    }
+
+    .rows-per-page {
+      color: #595C60;
+    }
+  }
+
+  .keys-currently-displayed {
+    color: #595C60;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .paging {
+    display: flex;
+    padding-left: 20px;
+
+    .page-nav {
+      color: var(--color-primary);
+      display: flex;
+      padding: unset;
+      background: none;
+
+      &:hover {
+        color: var(--color-primary-dark)
+      }
+    }
+  }
+}

--- a/saplings/profile/src/components/SaplingHeader.js
+++ b/saplings/profile/src/components/SaplingHeader.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import './SaplingHeader.scss';
+
+const SaplingHeader = ({ saplingName }) => {
+  return (
+    <section id="sapling-header">
+    <div className="sapling-name">
+      {saplingName}
+    </div>
+  </section>
+  );
+}
+
+SaplingHeader.propTypes = {
+  saplingName: PropTypes.string.isRequired,
+};
+
+export default SaplingHeader;

--- a/saplings/profile/src/components/SaplingHeader.scss
+++ b/saplings/profile/src/components/SaplingHeader.scss
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#sapling-header {
+  background: #ffffff;
+  position: relative;
+  display: flex;
+  padding: 1.5rem;
+  height: 56px;
+  box-sizing: border-box;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.14), 0px 1px 12px rgba(0, 0, 0, 0.12), 0px 2px 6px rgba(0, 0, 0, 0.1);
+  justify-content: flex-start;
+  align-items: flex-end;
+
+  .sapling-name {
+    font-family: Arial;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 24px;
+    color: #595C60;
+    align-self: center;
+  }
+}


### PR DESCRIPTION
This PR implements the key table in the profile sapling

The functioning key table displays the keys associated with the authenticated user. The `New Key` button uses the original profile sapling form to generate and add new keys.

Paging is not yet implemented for the table so all new keys will be added to the bottom of the table.

The delete button in the key actions menu is also not implemented.

Copyright headers are added to the new files that did not have them previously.

**Testing:**

1. Run the splinter-ui using either the biome docker-compose or set the necessary environment variables and use the oauth docker-compose
`docker-compose -f docker-compose-biome.yaml up --build`
OR
`docker-compose -f docker-compose-oauth.yaml up --build`

2. In a browser navigate to `http://localhost:3030`

3. Register/log in and select the profile tab in the left nav bar

4. Click the `+ New Key` button and add a new key

5. View the new key in the key table on the profile page

6. Select the activate button (check mark) from the available key actions and activate the key
The key should now show `Active` in the status column and the activate option should no longer appear in the key actions

8. Add a second key using the `+ New Key` button
There should now be two keys in the key table

9. Activate the second key
The second key should now show `Active` in the status column and the first key's status should be empty indicating it is no longer active. The first key should now have the activate option in the key actions again.