### PR TITLE
 Profile sapling key table modifications and paging

### DIFF
--- a/saplings/profile/package.json
+++ b/saplings/profile/package.json
@@ -20,6 +20,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
+    "react-table": "^7.6.3",
     "sjcl": "^1.0.8",
     "splinter-saplingjs": "github:cargill/splinter-saplingjs#master",
     "transact-sdk-javascript": "github:hyperledger/transact-sdk-javascript#master"

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -83,7 +83,20 @@ export function Profile() {
     setModalActive(true);
   };
 
+  const sortKeysActive = (allKeys, publicKey) => {
+    const keyIndex = allKeys.findIndex(key => key.public_key === publicKey);
+    const activeKey = allKeys[keyIndex];
+    allKeys.splice(keyIndex, 1);
+    setKeys([activeKey,...allKeys]);
+  };
+
+  sortKeysActive.propTypes = {
+    allKeys: proptypes.arrayOf(proptypes.object).isRequired,
+    publicKey: proptypes.string.isRequired,
+  };
+
   const updateKeyCallback = async () => {
+    let allKeys = [];
     setModalActive(false);
     try {
       const { splinterURL } = getSharedConfig().canopyConfig;
@@ -95,7 +108,12 @@ export function Profile() {
           request.setRequestHeader('Authorization', `Bearer ${user.token}`);
         }
       );
-      setKeys(JSON.parse(userKeys).data);
+      allKeys = JSON.parse(userKeys).data;
+      if (stateKeys) {
+        sortKeysActive(allKeys, stateKeys.publicKey);
+      } else {
+        setKeys(allKeys);
+      }
     } catch (err) {
       switch (err.code) {
         case '401':
@@ -153,6 +171,7 @@ export function Profile() {
           publicKey: public_key,
           privateKey
         });
+        sortKeysActive(keys, public_key);
         setModalActive(false);
       } catch (err) {
         openModalForm('enter-password', {

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -191,6 +191,7 @@ export function Profile() {
         <KeyTable
           keys={keys}
           activeKey={stateKeys && stateKeys.publicKey}
+          rowsPerPage='10'
           onAdd={() => openModalForm('add-key', {
             successFn: value => addKeyCallback(value)
           })}

--- a/saplings/profile/src/components/KeyTable.js
+++ b/saplings/profile/src/components/KeyTable.js
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import './KeyTable.scss';
 import PropTypes from 'prop-types';
 import Icon from '@material-ui/core/Icon';
 import KeyTableNav from './KeyTableNav';
 
-const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
+const KeyTable = ({ keys, activeKey, rowsPerPage, onAdd, onActivate, onEdit }) => {
+  const [page, setPage] = useState(0);
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
 
   const emptyRows = [];
   const rows = keys.map(key => {
@@ -74,16 +79,25 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
       </tr>
     )
   })
-  if (keys.length < 10) {
-    for (let i=0; i < 10-keys.length; i+=1) {
-      emptyRows.push(<tr className="empty-row"><td colSpan="6" className="keys-empty" /></tr>)
-    }
+
+  const numberEmptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
+
+  for (let i=0; i < numberEmptyRows; i+=1) {
+    emptyRows.push(<tr className="empty-row"><td colSpan="6" className="keys-empty" /></tr>)
   }
+
+  const start = page * rowsPerPage;
+  const end = parseFloat(page * rowsPerPage)+parseFloat(rowsPerPage);
 
   return (
     <section className="user-keys">
       <div className="table-actions">
-        <KeyTableNav totalKeys={keys.length} />
+        <KeyTableNav
+          totalKeys={keys.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onChangePage={handleChangePage}
+        />
         <button
           id="add-key"
           onClick={onAdd}
@@ -104,11 +118,19 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
               <th id="action-col">Action</th>
             </tr>
           </thead>
-          <tbody>{rows}{emptyRows}</tbody>
+          <tbody>
+            {rows.slice(start,end)}
+            {numberEmptyRows > 0 && emptyRows}
+          </tbody>
         </table>
       </div>
       <div className="table-actions">
-        <KeyTableNav totalKeys={keys.length} />
+      <KeyTableNav
+        totalKeys={keys.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onChangePage={handleChangePage}
+      />
       </div>
     </section>
   );
@@ -117,13 +139,15 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
 KeyTable.propTypes = {
   keys: PropTypes.arrayOf(PropTypes.object).isRequired,
   activeKey: PropTypes.string,
+  rowsPerPage: PropTypes.number,
   onAdd: PropTypes.func.isRequired,
   onActivate: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
 };
 
 KeyTable.defaultProps = {
-  activeKey: null
+  activeKey: null,
+  rowsPerPage: 10
 };
 
 export default KeyTable;

--- a/saplings/profile/src/components/KeyTable.js
+++ b/saplings/profile/src/components/KeyTable.js
@@ -130,6 +130,7 @@ const KeyTable = ({ keys, activeKey, rowsPerPage, onAdd, onActivate, onEdit }) =
         rowsPerPage={rowsPerPage}
         page={page}
         onChangePage={handleChangePage}
+        position='bottom'
       />
       </div>
     </section>

--- a/saplings/profile/src/components/KeyTable.js
+++ b/saplings/profile/src/components/KeyTable.js
@@ -44,6 +44,7 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
               {!isActive &&
                 <button
                   className="key-action-btn"
+                  title="Activate key"
                   onClick={e => {
                     e.preventDefault();
                     onActivate(key);
@@ -53,6 +54,7 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
                 </button>}
                 <button
                   className="key-action-btn"
+                  title="Edit key name"
                   onClick={e => {
                       e.preventDefault();
                       onEdit(key);
@@ -60,7 +62,9 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
                   >
                   <Icon>edit_icon</Icon>
                 </button>
-                <button className="key-action-btn">
+                <button
+                  className="key-action-btn"
+                  title="Delete key">
                   <Icon>delete_icon</Icon>
                 </button>
               </span>
@@ -82,7 +86,8 @@ const KeyTable = ({ keys, activeKey, onAdd, onActivate, onEdit }) => {
         <KeyTableNav totalKeys={keys.length} />
         <button
           id="add-key"
-          onClick={onAdd}>
+          onClick={onAdd}
+          title="Click to add new key">
           <div className="icon"><Icon>add_icon</Icon></div>
           New Key
         </button>

--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -62,6 +62,7 @@
   .table-wrapper {
     border-radius: 5px 5px 3px 3px;
     overflow-x: scroll;
+    height: 705px;
   }
 
   table {
@@ -86,7 +87,7 @@
       font-weight: bold;
       font-size: 12px;
       color: #545454;
-      padding: 2%;
+      padding: 0% 2%;
       background: #E4E4E4E4;
       text-align: left;
     }
@@ -133,6 +134,7 @@
       .button-wrapper {
         button#action-button{
           background: rgba(216, 216, 216, 0.5);
+          position: relative;
           display: flex;
           justify-content: center;
           border: none;
@@ -146,6 +148,7 @@
           .action-options {
             width: 0;
             height: 0;
+            z-index: 1;
             overflow: hidden;
             color: var(--color-primary);
             background: #EBEBEB;

--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -46,7 +46,6 @@
 
       .icon {
         color: #fff;
-        align-self: baseline;
         height: 24px;
         width: 24px;
         font-size: 11px;

--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -25,7 +25,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    padding: 1% 0%;
+    padding: 1% 0% 1% 2%;
 
     button#add-key {
       border: none;

--- a/saplings/profile/src/components/KeyTableNav.js
+++ b/saplings/profile/src/components/KeyTableNav.js
@@ -16,32 +16,34 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Icon from '@material-ui/core/Icon';
+import TablePagination from '@material-ui/core/TablePagination';
 import './KeyTableNav.scss';
 
-const KeyTableNav = ({ totalKeys }) => {
+const KeyTableNav = ({ totalKeys, rowsPerPage, page, onChangePage }) => {
   return (
     <div className="table-nav">
       <div className="total-keys">{totalKeys} Keys</div>
       <div className="row-info">
         <div className="rows-label">Rows per page:</div>
-        <div className="rows-per-page">10</div>
+        <div className="rows-per-page">{rowsPerPage}</div>
       </div>
-      <div className="keys-currently-displayed">1-{totalKeys} of {totalKeys}</div>
-      <div className="paging">
-        <div className="page-nav" title="Click to go to the previous page">
-          <Icon>keyboard_arrow_left_icon</Icon>
-        </div>
-        <div className="page-nav" title="Click to go to the next page">
-          <Icon>keyboard_arrow_right_icon</Icon>
-        </div>
-      </div>
+      <TablePagination
+          component="div"
+          count={totalKeys}
+          rowsPerPageOptions={[rowsPerPage]}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onChangePage={onChangePage}
+      />
     </div>
   );
 };
 
 KeyTableNav.propTypes = {
   totalKeys: PropTypes.number.isRequired,
+  rowsPerPage: PropTypes.number.isRequired,
+  page: PropTypes.object.isRequired,
+  onChangePage: PropTypes.func.isRequired,
 };
 
 export default KeyTableNav;

--- a/saplings/profile/src/components/KeyTableNav.js
+++ b/saplings/profile/src/components/KeyTableNav.js
@@ -29,8 +29,12 @@ const KeyTableNav = ({ totalKeys }) => {
       </div>
       <div className="keys-currently-displayed">1-{totalKeys} of {totalKeys}</div>
       <div className="paging">
-        <div className="page-nav"><Icon>keyboard_arrow_left_icon</Icon></div>
-        <div className="page-nav"><Icon>keyboard_arrow_right_icon</Icon></div>
+        <div className="page-nav" title="Click to go to the previous page">
+          <Icon>keyboard_arrow_left_icon</Icon>
+        </div>
+        <div className="page-nav" title="Click to go to the next page">
+          <Icon>keyboard_arrow_right_icon</Icon>
+        </div>
       </div>
     </div>
   );

--- a/saplings/profile/src/components/KeyTableNav.js
+++ b/saplings/profile/src/components/KeyTableNav.js
@@ -19,9 +19,10 @@ import PropTypes from 'prop-types';
 import TablePagination from '@material-ui/core/TablePagination';
 import './KeyTableNav.scss';
 
-const KeyTableNav = ({ totalKeys, rowsPerPage, page, onChangePage }) => {
+const KeyTableNav = ({ totalKeys, rowsPerPage, page, onChangePage, position }) => {
+  const isBottom = position === 'bottom';
   return (
-    <div className="table-nav">
+    <div className={`table-nav ${isBottom ? 'bottom' : ''}`}>
       <div className="total-keys">{totalKeys} Keys</div>
       <div className="row-info">
         <div className="rows-label">Rows per page:</div>
@@ -44,6 +45,11 @@ KeyTableNav.propTypes = {
   rowsPerPage: PropTypes.number.isRequired,
   page: PropTypes.object.isRequired,
   onChangePage: PropTypes.func.isRequired,
+  position: PropTypes.string,
 };
+
+KeyTableNav.defaultProps = {
+  position: null,
+}
 
 export default KeyTableNav;

--- a/saplings/profile/src/components/KeyTableNav.scss
+++ b/saplings/profile/src/components/KeyTableNav.scss
@@ -78,3 +78,7 @@
     }
   }
 }
+
+.bottom {
+  position: absolute;
+}

--- a/saplings/profile/src/components/KeyTableNav.scss
+++ b/saplings/profile/src/components/KeyTableNav.scss
@@ -43,6 +43,19 @@
     }
   }
 
+  .MuiTablePagination-caption {
+    font-style: normal;
+    font-weight: bold;
+    font-size: 14px;
+    color: #595C60;
+  }
+
+  button.MuiButtonBase-root {
+    color: var(--color-primary) !important;
+    padding: unset !important;
+    background: none !important;
+  }
+
   .keys-currently-displayed {
     color: #595C60;
     padding-left: 20px;


### PR DESCRIPTION
- Adds paging to the key table by using the material-ui TablePagination React component
- Adds labels to buttons that show when hovering the cursor
- Fixes the action options to stay in the action column. Previously, if the browser window was smaller than the table width, requiring horizontal scrolling, the expanded action options didn't stay in the action column
- Fixes the table to allow the action options for the last key in the table to expand beyond the bottom border of the table
- Adjusts the table navigation padding to align with column names in the key table

**Testing:**
1. Run the splinter-ui using either the biome docker-compose or set the necessary environment variables and use the oauth docker-compose
`docker-compose -f docker-compose-biome.yaml up --build`
OR
`docker-compose -f docker-compose-oauth.yaml up --build`

2. In a browser navigate to `http://localhost:3030`

3. Register/log in and select the profile tab in the left nav bar

4. Add at least 11 keys to the table to test paging

5. Hover cursor over buttons to see labels