### PR TITLE
Fix key table to always order active key first

### DIFF
--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -43,8 +43,16 @@ export function Profile() {
   const [stateKeys, setStateKeys] = useState(getKeys);
   const user = getUser();
 
+  const sortKeysActive = (allKeys, publicKey) => {
+    const keyIndex = allKeys.findIndex(key => key.public_key === publicKey);
+    const activeKey = allKeys[keyIndex];
+    allKeys.splice(keyIndex, 1);
+    setKeys([activeKey,...allKeys]);
+  };
+
   useEffect(() => {
     async function fetchUserKeys() {
+      let allKeys = [];
       if (user) {
         try {
           const { splinterURL } = getSharedConfig().canopyConfig;
@@ -56,7 +64,12 @@ export function Profile() {
               request.setRequestHeader('Authorization', `Bearer ${user.token}`);
             }
           );
-          setKeys(JSON.parse(userKeys).data);
+          allKeys = JSON.parse(userKeys).data;
+          if (stateKeys) {
+            sortKeysActive(allKeys, stateKeys.publicKey);
+          } else {
+            setKeys(allKeys);
+          }
         } catch (err) {
           switch (err.code) {
             case '401':
@@ -81,13 +94,6 @@ export function Profile() {
       params: adata
     });
     setModalActive(true);
-  };
-
-  const sortKeysActive = (allKeys, publicKey) => {
-    const keyIndex = allKeys.findIndex(key => key.public_key === publicKey);
-    const activeKey = allKeys[keyIndex];
-    allKeys.splice(keyIndex, 1);
-    setKeys([activeKey,...allKeys]);
   };
 
   sortKeysActive.propTypes = {


### PR DESCRIPTION
Currently the keys are sorted after editing and activating a key but if the page is refreshed the keys return to the order in which they were added meaning the active key may not be first in the table. This PR resolves this issue by sorting the keys after the rest api call to retrieve the keys.