### PR TITLE
Add oauth profile details to profile sapling

### DIFF
--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -17,7 +17,6 @@
 import React, { useEffect, useState } from 'react';
 import './Profile.scss';
 import proptypes from 'prop-types';
-import Icon from '@material-ui/core/Icon';
 import {
   decryptKey,
   getKeys,
@@ -26,6 +25,7 @@ import {
   setKeys as setSigningKeys
 } from 'splinter-saplingjs';
 import KeyTable from './components/KeyTable';
+import { DisplayProfilePicture } from './components/DisplayProfilePicture';
 import { ChangePasswordForm } from './forms/ChangePasswordForm';
 import { AddKeyForm } from './forms/AddKeyForm';
 import { UpdateKeyForm } from './forms/UpdateKeyForm';
@@ -243,9 +243,7 @@ export function Profile() {
     <div id="profile">
       <section className="profile-info">
         <div className="profile-photo">
-          <div className="icon">
-            <Icon>person_icon</Icon>
-          </div>
+          <DisplayProfilePicture image={profile.picture} />
         </div>
         <div className="user-details">
           <div className="name">{profile.name}</div>

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -40,8 +40,57 @@ export function Profile() {
     params: {}
   });
   const [keys, setKeys] = useState([]);
+  const [profile, setProfile] = useState({
+    userId: '',
+    subject: '',
+    name: '',
+    givenName: '',
+    familyName: '',
+    email: '',
+    picture: ''
+  });
   const [stateKeys, setStateKeys] = useState(getKeys);
   const user = getUser();
+
+  useEffect(() => {
+    async function fetchUserProfile() {
+      if (user) {
+        try {
+          const { splinterURL } = getSharedConfig().canopyConfig;
+          const userProfile = await http(
+            'GET',
+            `${splinterURL}/biome/profile`,
+            {},
+            request => {
+              request.setRequestHeader('Authorization', `Bearer ${user.token}`);
+            }
+          );
+          setProfile(JSON.parse(userProfile));
+        } catch (err) {
+          switch (err.status) {
+            case 401: {
+              window.location.href = `${window.location.origin}/login`;
+              break;
+            }
+            case 404: {
+              if (user) {
+                setProfile({
+                  ...profile,
+                  name: user.displayName
+                });
+              }
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      } else {
+        window.location.href = `${window.location.origin}/login`;
+      }
+    }
+    fetchUserProfile();
+  }, [user]);
 
   useEffect(() => {
     async function fetchUserKeys() {
@@ -199,8 +248,8 @@ export function Profile() {
           </div>
         </div>
         <div className="user-details">
-          <div className="name">{user && user.displayName}</div>
-          <div className="email">email@email.com</div>
+          <div className="name">{profile.name}</div>
+          <div className="email">{profile.email}</div>
         </div>
       </section>
       <section id="user-key-table">

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -58,8 +58,8 @@ export function Profile() {
           );
           setKeys(JSON.parse(userKeys).data);
         } catch (err) {
-          switch (err.code) {
-            case '401':
+          switch (err.status) {
+            case 401:
               window.location.href = `${window.location.origin}/login`;
               break;
             default:
@@ -115,8 +115,8 @@ export function Profile() {
         setKeys(allKeys);
       }
     } catch (err) {
-      switch (err.code) {
-        case '401':
+      switch (err.status) {
+        case 401:
           window.location.href = `${window.location.origin}/login`;
           break;
         default:

--- a/saplings/profile/src/Profile.scss
+++ b/saplings/profile/src/Profile.scss
@@ -114,7 +114,7 @@
 
     .label {
       width: fit-content;
-      color: var(--color-text-light--on-dark);
+      color: var(--color-text-light-on-dark);
     }
 
     .value {

--- a/saplings/profile/src/Profile.scss
+++ b/saplings/profile/src/Profile.scss
@@ -38,15 +38,7 @@
       align-items: center;
       display: flex;
       margin: 2% 2% 0% 0%;
-
-      .icon {
-        height: 102px;
-        width: 102px;
-        justify-content: center;
-        align-items: center;
-        display: flex;
-        transform: scale(4);
-      }
+      overflow: hidden;
     }
     .user-details {
       display: flex;

--- a/saplings/profile/src/components/DisplayProfilePicture.js
+++ b/saplings/profile/src/components/DisplayProfilePicture.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import './DisplayProfilePicture.scss';
+import proptypes from 'prop-types';
+import Icon from '@material-ui/core/Icon';
+
+export const DisplayProfilePicture = ({ image }) => {
+  if (image === '') {
+    return (
+      <div className="photo-default">
+        <Icon>person_icon</Icon>
+      </div>
+    );
+  }
+  if (image.includes("https://")) {
+    return (
+      <img className="oauth-profile-picture" src={image} alt="profile" />
+    );
+  }
+  const photoSource = `data:image/png;base64, ${image}`;
+  return (
+    <img className="oauth-profile-picture" src={photoSource} alt="profile" />
+  );
+};
+
+DisplayProfilePicture.propTypes = {
+  image: proptypes.string,
+};
+
+DisplayProfilePicture.defaultProps = {
+  image: '',
+};

--- a/saplings/profile/src/components/DisplayProfilePicture.scss
+++ b/saplings/profile/src/components/DisplayProfilePicture.scss
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.photo-default {
+  height: 102px;
+  width: 102px;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  transform: scale(4);
+}
+img.oauth-profile-picture {
+  width: 100%;
+  height: 100%;
+}

--- a/saplings/profile/src/http.js
+++ b/saplings/profile/src/http.js
@@ -33,7 +33,7 @@ export async function http(method, url, data, headerFn) {
       if (request.status >= 200 && request.status < 300) {
         resolve(request.response);
       } else {
-        reject(request.response);
+        reject(request);
       }
     };
     request.onerror = () => {


### PR DESCRIPTION
This PR adds the profile information collected from an OAuth provider to the profile sapling.

The profile information is fetched from the splinter `biome/profile` endpoint, if biome auth is used instead of oauth a default icon will be displayed in place of the profile picture and the username will be displayed in place of the name.


### **Testing:**

Set the following environment variables depending on the chosen oauth provider
```
OAUTH_CLIENT_ID=
OAUTH_CLIENT_SECRET=
OAUTH_PROVIDER=
OAUTH_OPENID_URL=
```
start splinter-ui in docker
`docker-compose -f docker-compose-oauth.yaml up --build`
Navigate to `http://localhost:3030` and register/login through the OAuth provider

Profile photo, name, and email associated with the account that was used to log in should be displayed at the top of the profile page.

Running the splinter admin-ui with the biome docker-compose file should result in a default person icon in place of the profile picture and the username in place of the name at the top of the profile page.