### PR TITLE
Display logo on home page

### DIFF
--- a/app/public/index.css
+++ b/app/public/index.css
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+div#logo {
+    background-image: var(--brand-img-url);
+    height: 100%;
+    width: 100%;
+    background-size: 150px;
+    background-repeat: no-repeat;
+    background-position: center;
+}

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -21,6 +21,7 @@ limitations under the License.
   <meta name="description" content="UI for Splinter" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="index.css">
   <title>Splinter</title>
 </head>
 
@@ -28,7 +29,9 @@ limitations under the License.
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div class="app">
     <div id="root" class="side-nav"></div>
-    <div id="sapling-container" class="view" />
+    <div id="sapling-container" class="view">
+        <div id="logo" />
+    </div>
   </div>
 </body>
 


### PR DESCRIPTION
Modify the landing page after login to display the splinter logo

### **Testing:**
run splinter-ui in docker with:
`docker-compose -f docker-compose-biome.yaml up --build`
Or set the appropriate environment variables for an oauth provider and run
`docker-compose -f docker-compose-oauth.yaml up --build`

go to http://localhost:3030 in a browser and register/login 

the initial page you see after successful login should have the splinter logo in the center