### PR TITLE
Update KeyTable header colors

### DIFF
--- a/saplings/profile/src/components/KeyTable.scss
+++ b/saplings/profile/src/components/KeyTable.scss
@@ -86,9 +86,9 @@
       font-style: normal;
       font-weight: bold;
       font-size: 12px;
-      color: #545454;
       padding: 0% 2%;
-      background: #E4E4E4E4;
+      color: var(--color-text-lighter--on-dark);
+      background: var(--color-grey);
       text-align: left;
     }
 


### PR DESCRIPTION
This updates the KeyTable component's header colors to use the theme
color variables. This helps keep the styling consistent between
saplings.

Signed-off-by: Davey Newhall <newhall@bitwise.io>