### PR TITLE
Fix jsx-no-bind lint

### DIFF
--- a/saplings/profile/src/forms/AddKeyForm.js
+++ b/saplings/profile/src/forms/AddKeyForm.js
@@ -125,7 +125,7 @@ export function AddKeyForm({ successFn }) {
       {!loading && (
         <MultiStepForm
           formName="Add key"
-          handleSubmit={submitAddKey}
+          handleSubmit={() => submitAddKey()}
           disabled={
             !(
               state.name &&


### PR DESCRIPTION
This change fixes a lint where a function should not be directly bound to a JSX tag attribute.
