### PR TITLE
Update node base image in some Dockerfiles

### DIFF
--- a/Dockerfile-biome
+++ b/Dockerfile-biome
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Canopy build stage
-FROM node:lts-alpine as canopy-app-build-stage
+FROM node:14.18.1-alpine3.11 as canopy-app-build-stage
 
 RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 WORKDIR /splinter_ui
@@ -28,7 +28,7 @@ ARG REPO_VERSION
 RUN tar c -z . -f ../splinter_ui_v${REPO_VERSION}.tar.gz
 
 # Sapling build stage
-FROM node:lts-alpine as sapling-build-stage
+FROM node:14.18.1-alpine3.11 as sapling-build-stage
 
 RUN apk update && apk add git
 

--- a/Dockerfile-oauth
+++ b/Dockerfile-oauth
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Canopy build stage
-FROM node:lts-alpine as canopy-app-build-stage
+FROM node:14.18.1-alpine3.11 as canopy-app-build-stage
 
 RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 WORKDIR /splinter_ui
@@ -28,7 +28,7 @@ ARG REPO_VERSION
 RUN tar c -z . -f ../splinter_ui_v${REPO_VERSION}.tar.gz
 
 # Sapling build stage
-FROM node:lts-alpine as sapling-build-stage
+FROM node:14.18.1-alpine3.11 as sapling-build-stage
 
 RUN apk update && apk add git
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 WORKDIR /splinter_ui

--- a/ci/package-sapling.dockerfile
+++ b/ci/package-sapling.dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk update \
  && apk add git

--- a/docker/test-app
+++ b/docker/test-app
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 WORKDIR /app
 

--- a/sapling-dev-server/Dockerfile
+++ b/sapling-dev-server/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk update && apk add git
 

--- a/saplings/circuits/test/Dockerfile
+++ b/saplings/circuits/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for running unit tests and lint on the circuits sapling
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 WORKDIR /saplings/circuits
 

--- a/saplings/oauth-login/test/Dockerfile
+++ b/saplings/oauth-login/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for running unit tests and lint on the oauth-login sapling
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 WORKDIR /saplings/oauth-login
 

--- a/saplings/profile/test/Dockerfile
+++ b/saplings/profile/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for running unit tests and lint on the profile sapling
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 WORKDIR /saplings/profile
 

--- a/saplings/register-login/test/Dockerfile
+++ b/saplings/register-login/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for running unit tests and lint on the register-login sapling
-FROM node:lts-alpine
+FROM node:14.18.1-alpine3.11
 
 WORKDIR /saplings/register-login
 


### PR DESCRIPTION
node:lts-alpine was updated to be based on alpine 3.14 instead of 3.11
and use node v16 instead of v14. splinter-ui currently is incompatible
with node v16.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>