### PR TITLE
Update docker compose to assign necessary permissions

### DIFF
--- a/docker-compose-oauth.yaml
+++ b/docker-compose-oauth.yaml
@@ -41,7 +41,11 @@ services:
       bash -c "
         if [ ! -f /keys/alpha.priv ]
         then
-          splinter admin keygen alpha -d /keys
+          splinter keygen alpha --key-dir /keys
+        fi && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /keys/alpha.pub) > /etc/splinter/allow_keys
         fi && \
         until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
@@ -52,6 +56,7 @@ services:
           splinter-cli cert generate --force
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
+        splinter keygen --system --skip && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
         --rest-api-endpoint http://0.0.0.0:8085 \
@@ -63,6 +68,7 @@ services:
         --tls-client-key /etc/splinter/certs/private/client.key \
         --tls-server-cert /etc/splinter/certs/server.crt \
         --tls-server-key /etc/splinter/certs/private/server.key \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-alpha:5432/splinter \
         --tls-insecure
       "
@@ -116,7 +122,11 @@ services:
       bash -c "
         if [ ! -f /keys/beta.priv ]
         then
-          splinter admin keygen beta -d /keys
+          splinter keygen beta --key-dir /keys
+        fi && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /keys/beta.pub) > /etc/splinter/allow_keys
         fi && \
         until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
@@ -127,6 +137,7 @@ services:
           splinter-cli cert generate --force
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
+        splinter keygen --system --skip && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
         --rest-api-endpoint http://0.0.0.0:8085 \
@@ -138,6 +149,7 @@ services:
         --tls-client-key /etc/splinter/certs/private/client.key \
         --tls-server-cert /etc/splinter/certs/server.crt \
         --tls-server-key /etc/splinter/certs/private/server.key \
+        --enable-biome-credentials \
         --database postgres://admin:admin@splinter-db-beta:5432/splinter \
         --tls-insecure
       "
@@ -177,7 +189,7 @@ services:
 # ---== shared services ==---
 
   generate-registry:
-    image: splintercommunity/splinter-cli:master
+    image: splintercommunity/splinter-cli:main
     volumes:
       - registry:/registry
       - alpha-keys:/alpha_keys
@@ -187,8 +199,8 @@ services:
         if [ ! -f /registry/registry.yaml ]
         then
           # generate keys
-          splinter admin keygen alice -d /registry
-          splinter admin keygen bob -d /registry
+          splinter keygen alice --key-dir /registry
+          splinter keygen bob --key-dir /registry
           # check if splinterd-alpha is available (will get 401 because no auth is provided)
           while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 401 ]] ; do
              >&2 echo \"splinterd is unavailable - sleeping\"

--- a/docker-compose-oauth.yaml
+++ b/docker-compose-oauth.yaml
@@ -57,7 +57,7 @@ services:
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
         splinter keygen --system --skip && \
-        splinterd -vv \
+        splinterd -v \
         --registries http://registry-server:80/registry.yaml \
         --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
@@ -105,6 +105,50 @@ services:
     environment:
       SPLINTER_URL: 'http://splinterd-alpha:8085'
 
+  alpha-node-permissions:
+    image: splintercommunity/splinter-cli:main
+    volumes:
+      - alpha-keys:/alpha_keys
+    depends_on:
+      - splinterd-alpha
+    command: |
+      bash -c "
+      # This service simulates the work that would normally be done by an admin, assigning
+      # the necessary permissions to the logged in users. This should be used for example
+      # purposes only.
+        # check if splinterd-alpha is available (will get 401 because no auth is provided)
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 401 ]] ; do
+            >&2 echo \"splinterd is unavailable - sleeping\"
+            sleep 1
+        done
+        num_users=0
+        # while splinterd-alpha is running assign the admin role to all logged in users
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -eq 401 ]] ; do
+          # check that the list of splinter users is not empty
+          alpha_users=$$(splinter user list --url http://splinterd-alpha:8085 --key /alpha_keys/alpha.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          while [[ -z $$alpha_users ]] ; do
+            sleep 5
+            alpha_users=$$(splinter user list --url http://splinterd-alpha:8085 --key /alpha_keys/alpha.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          done
+          if [ $$num_users -ne $$(echo $$alpha_users | wc -w) ]
+          then
+            num_users=$$(echo $$alpha_users | wc -w)
+            for user_id in $$alpha_users ; do
+              # check that the admin role has not already been assigned
+              if [[ $$(splinter authid show --url http://splinterd-alpha:8085 --key /alpha_keys/alpha.priv --id-user $$user_id) != *"admin"* ]]
+              then
+                splinter authid create \
+                  --url http://splinterd-alpha:8085 \
+                  --key /alpha_keys/alpha.priv \
+                  --role admin \
+                  --id-user $$user_id
+              fi
+            done
+          fi
+          sleep 5
+        done
+      "
+
 # ---== beta node ==---
 
   splinterd-beta:
@@ -138,7 +182,7 @@ services:
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
         splinter keygen --system --skip && \
-        splinterd -vv \
+        splinterd -v \
         --registries http://registry-server:80/registry.yaml \
         --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
@@ -185,6 +229,50 @@ services:
       - '3031:80'
     environment:
       SPLINTER_URL: 'http://splinterd-beta:8085'
+
+  beta-node-permissions:
+    image: splintercommunity/splinter-cli:main
+    volumes:
+      - beta-keys:/beta_keys
+    depends_on:
+      - splinterd-beta
+    command: |
+      bash -c "
+      # This service simulates the work that would normally be done by an admin, assigning
+      # the necessary permissions to the logged in users. This should be used for example
+      # purposes only.
+        # check if splinterd-beta is available (will get 401 because no auth is provided)
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 401 ]] ; do
+            >&2 echo \"splinterd is unavailable - sleeping\"
+            sleep 1
+        done
+        num_users=0
+        # while splinterd-beta is running assign the admin role to all logged in users
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -eq 401 ]] ; do
+          # check that the list of splinter users is not empty
+          beta_users=$$(splinter user list --url http://splinterd-beta:8085 --key /beta_keys/beta.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          while [[ -z $$beta_users ]] ; do
+            sleep 5
+            beta_users=$$(splinter user list --url http://splinterd-beta:8085 --key /beta_keys/beta.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          done
+          if [ $$num_users -ne $$(echo $$beta_users | wc -w) ]
+          then
+            num_users=$$(echo $$beta_users | wc -w)
+            for user_id in $$beta_users ; do
+              # check that the admin role has not already been assigned
+              if [[ $$(splinter authid show --url http://splinterd-beta:8085 --key /beta_keys/beta.priv --id-user $$user_id) != *"admin"* ]]
+              then
+                splinter authid create \
+                  --url http://splinterd-beta:8085 \
+                  --key /beta_keys/beta.priv \
+                  --role admin \
+                  --id-user $$user_id
+              fi
+            done
+          fi
+          sleep 5
+        done
+      "
 
 # ---== shared services ==---
 


### PR DESCRIPTION
In order to create circuits in the splinter admin UI, a user must have the necessary permissions.

This PR adds an `alpha-node-permissions` and a `beta-node-permissions` service to the oauth docker-compose file. These services use the "splinter user list" and "splinter authid create" cli commands to assign the admin role to any user that logs into the node.

This PR fixes the oauth docker compose only. A future PR will be created to fix the biome docker compose.