### PR TITLE
Update biome example

### DIFF
--- a/docker-compose-biome.yaml
+++ b/docker-compose-biome.yaml
@@ -26,7 +26,7 @@ services:
   # ---== alpha node ==---
 
   splinterd-alpha:
-    image: splintercommunity/splinterd:master
+    image: splintercommunity/splinterd:experimental
     container_name: splinterd-alpha
     hostname: splinterd-alpha
     expose:
@@ -41,7 +41,11 @@ services:
       bash -c "
         if [ ! -f /keys/alpha.priv ]
         then
-          splinter admin keygen alpha -d /keys
+          splinter keygen alpha --key-dir /keys
+        fi && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /keys/alpha.pub) > /etc/splinter/allow_keys
         fi && \
         until PGPASSWORD=admin psql -h splinter-db-alpha -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
@@ -52,9 +56,10 @@ services:
           splinter-cli cert generate --force
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
+        splinter keygen --system --skip && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoints tcps://splinterd-alpha:8044 \
         --node-id alpha-node-000 \
@@ -96,7 +101,7 @@ services:
 # ---== beta node ==---
 
   splinterd-beta:
-    image: splintercommunity/splinterd:master
+    image: splintercommunity/splinterd:experimental
     container_name: splinterd-beta
     hostname: splinterd-beta
     expose:
@@ -110,7 +115,11 @@ services:
       bash -c "
         if [ ! -f /keys/beta.priv ]
         then
-          splinter admin keygen beta -d /keys
+          splinter keygen beta --key-dir /keys
+        fi && \
+        if [ ! -s /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /keys/beta.pub) > /etc/splinter/allow_keys
         fi && \
         until PGPASSWORD=admin psql -h splinter-db-beta -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
@@ -121,9 +130,10 @@ services:
           splinter-cli cert generate --force
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
+        splinter keygen --system --skip && \
         splinterd -vv \
         --registries http://registry-server:80/registry.yaml \
-        --rest-api-endpoint 0.0.0.0:8085 \
+        --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
         --advertised-endpoints tcps://splinterd-beta:8044 \
         --node-id beta-node-000 \
@@ -165,7 +175,7 @@ services:
 # ---== shared services ==---
 
   generate-registry:
-    image: splintercommunity/splinter-cli:master
+    image: splintercommunity/splinter-cli:main
     volumes:
       - registry:/registry
       - alpha-keys:/alpha_keys
@@ -175,8 +185,8 @@ services:
         if [ ! -f /registry/registry.yaml ]
         then
           # generate keys
-          splinter admin keygen alice -d /registry
-          splinter admin keygen bob -d /registry
+          splinter keygen alice --key-dir /registry
+          splinter keygen bob --key-dir /registry
           # check if splinterd-alpha is available (will get 401 because no auth is provided)
           while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 401 ]] ; do
              >&2 echo \"splinterd is unavailable - sleeping\"

--- a/docker-compose-biome.yaml
+++ b/docker-compose-biome.yaml
@@ -57,7 +57,7 @@ services:
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter && \
         splinter keygen --system --skip && \
-        splinterd -vv \
+        splinterd -v \
         --registries http://registry-server:80/registry.yaml \
         --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
@@ -98,6 +98,50 @@ services:
     environment:
       SPLINTER_URL: 'http://splinterd-alpha:8085'
 
+  alpha-node-permissions:
+    image: splintercommunity/splinter-cli:experimental
+    volumes:
+      - alpha-keys:/alpha_keys
+    depends_on:
+      - splinterd-alpha
+    command: |
+      bash -c "
+      # This service simulates the work that would normally be done by an admin, assigning
+      # the necessary permissions to the logged in users. This should be used for example
+      # purposes only.
+        # check if splinterd-alpha is available (will get 401 because no auth is provided)
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -ne 401 ]] ; do
+            >&2 echo \"splinterd is unavailable - sleeping\"
+            sleep 1
+        done
+        num_users=0
+        # while splinterd-alpha is running assign the admin role to all logged in users
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-alpha:8085/status) -eq 401 ]] ; do
+          # check that the list of splinter users is not empty
+          alpha_users=$$(splinter user list --url http://splinterd-alpha:8085 --key /alpha_keys/alpha.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          while [[ -z $$alpha_users ]] ; do
+            sleep 5
+            alpha_users=$$(splinter user list --url http://splinterd-alpha:8085 --key /alpha_keys/alpha.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          done
+          if [ $$num_users -ne $$(echo $$alpha_users | wc -w) ]
+          then
+            num_users=$$(echo $$alpha_users | wc -w)
+            for user_id in $$alpha_users ; do
+              # check that the admin role has not already been assigned
+              if [[ $$(splinter authid show --url http://splinterd-alpha:8085 --key /alpha_keys/alpha.priv --id-user $$user_id) != *"admin"* ]]
+              then
+                splinter authid create \
+                  --url http://splinterd-alpha:8085 \
+                  --key /alpha_keys/alpha.priv \
+                  --role admin \
+                  --id-user $$user_id
+              fi
+            done
+          fi
+          sleep 5
+        done
+      "
+
 # ---== beta node ==---
 
   splinterd-beta:
@@ -131,7 +175,7 @@ services:
         fi && \
         splinter database migrate -C postgres://admin:admin@splinter-db-beta:5432/splinter && \
         splinter keygen --system --skip && \
-        splinterd -vv \
+        splinterd -v \
         --registries http://registry-server:80/registry.yaml \
         --rest-api-endpoint http://0.0.0.0:8085 \
         --network-endpoints tcps://0.0.0.0:8044 \
@@ -171,6 +215,50 @@ services:
       - '3031:80'
     environment:
       SPLINTER_URL: 'http://splinterd-beta:8085'
+
+  beta-node-permissions:
+    image: splintercommunity/splinter-cli:experimental
+    volumes:
+      - beta-keys:/beta_keys
+    depends_on:
+      - splinterd-beta
+    command: |
+      bash -c "
+      # This service simulates the work that would normally be done by an admin, assigning
+      # the necessary permissions to the logged in users. This should be used for example
+      # purposes only.
+        # check if splinterd-beta is available (will get 401 because no auth is provided)
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -ne 401 ]] ; do
+            >&2 echo \"splinterd is unavailable - sleeping\"
+            sleep 1
+        done
+        num_users=0
+        # while splinterd-beta is running assign the admin role to all logged in users
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-beta:8085/status) -eq 401 ]] ; do
+          # check that the list of splinter users is not empty
+          beta_users=$$(splinter user list --url http://splinterd-beta:8085 --key /beta_keys/beta.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          while [[ -z $$beta_users ]] ; do
+            sleep 5
+            beta_users=$$(splinter user list --url http://splinterd-beta:8085 --key /beta_keys/beta.priv --format csv | sed 1d | grep -o '^[^,]\+')
+          done
+          if [ $$num_users -ne $$(echo $$beta_users | wc -w) ]
+          then
+            num_users=$$(echo $$beta_users | wc -w)
+            for user_id in $$beta_users ; do
+              # check that the admin role has not already been assigned
+              if [[ $$(splinter authid show --url http://splinterd-beta:8085 --key /beta_keys/beta.priv --id-user $$user_id) != *"admin"* ]]
+              then
+                splinter authid create \
+                  --url http://splinterd-beta:8085 \
+                  --key /beta_keys/beta.priv \
+                  --role admin \
+                  --id-user $$user_id
+              fi
+            done
+          fi
+          sleep 5
+        done
+      "
 
 # ---== shared services ==---
 

--- a/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
+++ b/saplings/circuits/src/components/circuitDetails/CircuitDetails.js
@@ -66,7 +66,7 @@ const CircuitDetails = () => {
     const fetchNodes = async () => {
       if (user && circuitState.circuit) {
         try {
-          const apiNodes = await getNodeRegistry();
+          const apiNodes = await getNodeRegistry(user.token);
           const filteredNodes = apiNodes.filter(
             node =>
               !!circuitState.circuit.members.find(id => id === node.identity)

--- a/saplings/profile/src/Profile.js
+++ b/saplings/profile/src/Profile.js
@@ -78,7 +78,7 @@ export function Profile({keys, setKeys}) {
               window.location.href = `${window.location.origin}/login`;
               break;
             }
-            case 404: {
+            case 500: {
               if (user) {
                 setProfile({
                   ...profile,


### PR DESCRIPTION
- Update the biome docker compose to use and work with current splinter images
- Add an alpha-node-permissions and a beta-node-permissions service to the biome docker-compose file. These services use the "splinter user list" and "splinter authid create" cli commands to assign the admin role to any user that logs into the node in the same way that  #104 does for the OAuth example.
- Fix the call to `getNodeRegistry` in the circuit details componenet to pass in the user's token so that it can be used in the call made to `/registry/nodes`, when viewing circuit details.
- Update the method for setting the user profile when one does not exist.