### PR TITLE
Add permission error

### DIFF
--- a/saplings/circuits/package.json
+++ b/saplings/circuits/package.json
@@ -32,6 +32,8 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
+    "@material-ui/core": "^4.12.3",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/saplings/circuits/src/components/Content.js
+++ b/saplings/circuits/src/components/Content.js
@@ -17,8 +17,10 @@
 import React from 'react';
 import { useLocalNodeState } from '../state/localNode';
 import { useCircuitsState } from '../state/circuits';
+import { checkUserCircuitPermission } from '../state/permissions';
 
 import CircuitsTable from './circuitsTable/Table';
+import { PermissionError } from './PermissionError';
 
 import './Content.scss';
 
@@ -34,8 +36,19 @@ const Content = () => {
     ).length;
   }
 
+  const permission = checkUserCircuitPermission();
+
   return (
     <div className="main-content">
+      <div
+        className={
+          !permission.circuitPermission
+            ? 'permission-error-message'
+            : 'no-permission-error-message'
+        }
+      >
+        <PermissionError />
+      </div>
       <div className="midContent">
         <div className="circuit-stats">
           <div className="stat total-circuits">

--- a/saplings/circuits/src/components/Content.scss
+++ b/saplings/circuits/src/components/Content.scss
@@ -21,6 +21,10 @@
   margin: 2.5rem 3rem 0 3rem;
   max-height: 75%;
 
+  .no-permission-error-message {
+    visibility: hidden;
+  }
+
   .midContent {
     display: flex;
     flex-direction: row;

--- a/saplings/circuits/src/components/PermissionError.js
+++ b/saplings/circuits/src/components/PermissionError.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2018-2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import proptypes from 'prop-types';
+import Icon from '@material-ui/core/Icon';
+import './PermissionError.scss';
+
+export const PermissionError = ({ contact }) => {
+  return (
+    <div className="permission-page-block">
+      <div className="permission-error-box">
+        <div className="permission-error">
+          <div className="error-header">
+            <div className="error-header-icon">
+              <Icon>error_outline_icon</Icon>
+            </div>
+            <div className="error-header-text">Access Denied</div>
+          </div>
+          <div className="error-text">
+            Account does not have the required permissions to access this page.
+            {contact}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+PermissionError.propTypes = {
+  contact: proptypes.string
+};
+
+PermissionError.defaultProps = {
+  contact: ''
+};

--- a/saplings/circuits/src/components/PermissionError.scss
+++ b/saplings/circuits/src/components/PermissionError.scss
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.permission-page-block {
+   background-color: rgba(255,255,255,.5);
+   z-index: 9999999;
+   top: 0;
+   left: 75px;
+   right: 0;
+   bottom: 0;
+   position: fixed;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+
+   .permission-error-box {
+      background-color: var(--color-light-grey);
+      border-radius: 10px;
+      display: flex;
+      height: 200px;
+      width: 500px;
+      border: 1px solid var(--color-grey);
+
+      .permission-error {
+         display: flex;
+         flex-direction: column;
+
+            .error-header {
+               display: flex;
+               flex-direction: row;
+               padding-left: 20px;
+               padding-right: 20px;
+               padding-top: 20px;
+         
+            .error-header-icon {
+               padding-right: 10px;
+               padding-left: 10px;
+               color: var(--color-attention);
+            }
+            .error-header-text {
+               font-weight: bold;
+               color: var(--color-grey);
+               display: flex;
+               align-self: center;
+            }
+         }
+         .error-text {
+            color: var(--color-grey);
+            padding: 20px;
+         }
+      }
+   }
+}

--- a/saplings/circuits/src/state/permissions.js
+++ b/saplings/circuits/src/state/permissions.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2018-2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getUser } from 'splinter-saplingjs';
+import { useEffect, useState } from 'react';
+import { listCircuits } from '../api/splinter';
+
+function checkUserCircuitPermission() {
+  const user = getUser();
+
+  const [userCircuitPermission, setUserCircuitPermission] = useState({
+    circuitPermission: null
+  });
+  useEffect(() => {
+    const getPermission = async () => {
+      if (user) {
+        try {
+          await listCircuits(user.token);
+          setUserCircuitPermission({ circuitPermission: true });
+        } catch (error) {
+          if (error.code === '401') {
+            setUserCircuitPermission({ circuitPermission: false });
+          } else {
+            throw Error(
+              `Error checking user circuit permission: ${error.json.message}`
+            );
+          }
+        }
+      }
+    };
+    getPermission();
+  }, [user]);
+  return userCircuitPermission;
+}
+
+export { checkUserCircuitPermission };


### PR DESCRIPTION
- Add a permission error component that can be added to pages that a user does not have the valid permissions to access
- Add a function for the circuit sapling to check if a user has the necessary permissions to view the circuits page
- Add the permission check and component to the circuits page

Testing:
1. remove the `alpha-node-permissions` service from the docker-compose-biome.yaml file.
2. Start the splinter UI using this docker compose file
3. Go to localhost:3030, register, and click on the circuits tab to see the permission error that will come up if a user does not have the necessary permissions
4. Go to localhost:3031, register, and click on the circuits tab to see the circuits page is displayed as usual if a user does have the necessary permissions 